### PR TITLE
Add lifecycle rule to ignore task-definition changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 
+
 ## Usage
 
 ```hcl
@@ -73,7 +74,6 @@ Available targets:
 | ecr_repository_name | The name of the ECR repository to store images. | string | - | yes |
 | ecs_cluster_arn | The ARN of the ECS cluster where service will be provisioned. | string | - | yes |
 | family | The name used for multiple versions of a task definition. | string | `web` | no |
-| healthcheck | A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | map | `<map>` | no |
 | launch_type | The launch type on which to run your service. Valid values are EC2 and FARGATE. | string | `FARGATE` | no |
 | name | The name of the app to be used in labels. | string | - | yes |
 | namespace | The namespace to be used in labels. | string | - | yes |
@@ -119,11 +119,11 @@ Check out these related projects.
 
 File a GitHub [issue](https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/issues), send us an [email][email] or join our [Slack Community][slack].
 
-## Commerical Support
+## Commercial Support
 
 Work directly with our team of DevOps experts via email, slack, and video conferencing. 
 
-We provide *commercial support* for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a fulltime engineer. 
+We provide [*commercial support*][commercial_support] for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a full-time engineer. 
 
 [![E-Mail](https://img.shields.io/badge/email-hello@cloudposse.com-blue.svg)](mailto:hello@cloudposse.com)
 
@@ -133,7 +133,7 @@ We provide *commercial support* for all of our [Open Source][github] projects. A
 - **Bug Fixes.** We'll rapidly work to fix any bugs in our projects.
 - **Build New Terraform Modules.** We'll develop original modules to provision infrastructure.
 - **Cloud Architecture.** We'll assist with your cloud strategy and design.
-- **Implementation.** We'll provide hands on support to implement our reference architectures. 
+- **Implementation.** We'll provide hands-on support to implement our reference architectures. 
 
 
 ## Community Forum
@@ -217,6 +217,7 @@ Check out [our other projects][github], [apply for a job][jobs], or [hire us][hi
   [docs]: https://docs.cloudposse.com/
   [website]: https://cloudposse.com/
   [github]: https://github.com/cloudposse/
+  [commercial_support]: https://github.com/orgs/cloudposse/projects
   [jobs]: https://cloudposse.com/jobs/
   [hire]: https://cloudposse.com/contact/
   [slack]: https://slack.cloudposse.com/

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -15,7 +15,6 @@
 | ecr_repository_name | The name of the ECR repository to store images. | string | - | yes |
 | ecs_cluster_arn | The ARN of the ECS cluster where service will be provisioned. | string | - | yes |
 | family | The name used for multiple versions of a task definition. | string | `web` | no |
-| healthcheck | A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | map | `<map>` | no |
 | launch_type | The launch type on which to run your service. Valid values are EC2 and FARGATE. | string | `FARGATE` | no |
 | name | The name of the app to be used in labels. | string | - | yes |
 | namespace | The namespace to be used in labels. | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -190,4 +190,8 @@ resource "aws_ecs_service" "default" {
     container_name   = "${var.container_name}"
     container_port   = "${var.container_port}"
   }
+
+  lifecycle {
+    ignore_changes = ["task_definition"]
+  }
 }


### PR DESCRIPTION
## what
Add a lifecycle rule to ignore changes to task-defintion

## why
There is a known CD issue currently with Terraform and ECS - tracked in detail on this issue:
https://github.com/terraform-providers/terraform-provider-aws/issues/632

For now ignoring the task-definition changes will allow to make changes to other supporting modules (i.e. autoscaling) without rolling back the task definition to an older version. This is an example without the lifecycle rule, showing the sv-staging-data-model app being rolled back to an older image:

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ module.data_model_web_app.module.autoscaling.aws_appautoscaling_target.default
      max_capacity:                              "10" => "6"
      min_capacity:                              "5" => "3"

  ~ module.data_model_web_app.module.ecs_alb_service_task.aws_ecs_service.default
      desired_count:                             "5" => "3"
      task_definition:                           "sv-staging-data-model:18" => "sv-staging-data-model:17"
```