### PR TITLE
Make volumes configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Available targets:
 | deployment_minimum_healthy_percent | The lower limit (as a percentage of `desired_count`) of the number of tasks that must remain running and healthy in a service during a deployment | string | `100` | no |
 | desired_count | The number of instances of the task definition to place and keep running | string | `1` | no |
 | ecs_cluster_arn | The ARN of the ECS cluster where service will be provisioned | string | - | yes |
+| health_check_grace_period_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers. | string | `0` | no |
 | launch_type | The launch type on which to run your service. Valid values are EC2 and FARGATE | string | `FARGATE` | no |
 | name | Solution name, e.g. 'app' or 'cluster' | string | - | yes |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |
@@ -166,6 +167,7 @@ Available targets:
 | tags | Additional tags (e.g. `map('BusinessUnit`,`XYZ`) | map | `<map>` | no |
 | task_cpu | The number of CPU units used by the task. If using Fargate launch type `task_cpu` must match supported memory values (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | string | `256` | no |
 | task_memory | The amount of memory (in MiB) used by the task. If using Fargate launch type `task_memory` must match supported cpu value (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | string | `512` | no |
+| volumes | Task volume definitions as list of maps | list | `<list>` | no |
 | vpc_id | The VPC ID where resources are created | string | - | yes |
 
 ## Outputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -12,6 +12,7 @@
 | deployment_minimum_healthy_percent | The lower limit (as a percentage of `desired_count`) of the number of tasks that must remain running and healthy in a service during a deployment | string | `100` | no |
 | desired_count | The number of instances of the task definition to place and keep running | string | `1` | no |
 | ecs_cluster_arn | The ARN of the ECS cluster where service will be provisioned | string | - | yes |
+| health_check_grace_period_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers. | string | `0` | no |
 | launch_type | The launch type on which to run your service. Valid values are EC2 and FARGATE | string | `FARGATE` | no |
 | name | Solution name, e.g. 'app' or 'cluster' | string | - | yes |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |
@@ -22,6 +23,7 @@
 | tags | Additional tags (e.g. `map('BusinessUnit`,`XYZ`) | map | `<map>` | no |
 | task_cpu | The number of CPU units used by the task. If using Fargate launch type `task_cpu` must match supported memory values (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | string | `256` | no |
 | task_memory | The amount of memory (in MiB) used by the task. If using Fargate launch type `task_memory` must match supported cpu value (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | string | `512` | no |
+| volumes | Task volume definitions as list of maps | list | `<list>` | no |
 | vpc_id | The VPC ID where resources are created | string | - | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ resource "aws_ecs_task_definition" "default" {
   execution_role_arn       = "${aws_iam_role.ecs_exec.arn}"
   task_role_arn            = "${aws_iam_role.ecs_task.arn}"
   tags                     = "${module.default_label.tags}"
+  volume                   = "${var.volumes}"
 }
 
 # IAM

--- a/variables.tf
+++ b/variables.tf
@@ -113,3 +113,9 @@ variable "health_check_grace_period_seconds" {
   description = "Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers."
   default     = 0
 }
+
+variable "volumes" {
+  type = "list"
+  description = "Task volume definitions as list of maps"
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -115,7 +115,7 @@ variable "health_check_grace_period_seconds" {
 }
 
 variable "volumes" {
-  type = "list"
+  type        = "list"
   description = "Task volume definitions as list of maps"
   default     = []
 }


### PR DESCRIPTION
Allows to add volume definitions to task like this

```
module "alb_service_task" {
  source                    = "../terraform-aws-ecs-alb-service-task"
...
  volumes = [
    {
      name = "${module.label_base.id}-data"
      docker_volume_configuration = [
        {
          scope         = "shared"
          autoprovision = true
        },
      ]
    },
  ]
}
```