### PR TITLE
Fix name for `"aws_security_group" "ecs_service"`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Cloud Posse, LLC
+   Copyright 2018-2019 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -156,16 +156,17 @@ Available targets:
 | deployment_minimum_healthy_percent | The lower limit (as a percentage of `desired_count`) of the number of tasks that must remain running and healthy in a service during a deployment | string | `100` | no |
 | desired_count | The number of instances of the task definition to place and keep running | string | `1` | no |
 | ecs_cluster_arn | The ARN of the ECS cluster where service will be provisioned | string | - | yes |
-| health_check_grace_period_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers. | string | `0` | no |
-| launch_type | The launch type on which to run your service. Valid values are EC2 and FARGATE | string | `FARGATE` | no |
+| health_check_grace_period_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers | string | `0` | no |
+| ignore_changes_task_definition | Whether to ignore changes in container definition and task definition in the ECS service | string | `true` | no |
+| launch_type | The launch type on which to run your service. Valid values are `EC2` and `FARGATE` | string | `FARGATE` | no |
 | name | Solution name, e.g. 'app' or 'cluster' | string | - | yes |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |
-| network_mode | The network mode to use for the task. This is required to be awsvpc for FARGATE `launch_type` | string | `awsvpc` | no |
+| network_mode | The network mode to use for the task. This is required to be awsvpc for `FARGATE` `launch_type` | string | `awsvpc` | no |
 | private_subnet_ids | Private subnet IDs | list | - | yes |
-| security_group_ids | Security group IDs to allow in Service network_configuration | list | - | yes |
+| security_group_ids | Security group IDs to allow in Service `network_configuration` | list | - | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | - | yes |
 | tags | Additional tags (e.g. `map('BusinessUnit`,`XYZ`) | map | `<map>` | no |
-| task_cpu | The number of CPU units used by the task. If using Fargate launch type `task_cpu` must match supported memory values (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | string | `256` | no |
+| task_cpu | The number of CPU units used by the task. If using `FARGATE` launch type `task_cpu` must match supported memory values (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | string | `256` | no |
 | task_memory | The amount of memory (in MiB) used by the task. If using Fargate launch type `task_memory` must match supported cpu value (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | string | `512` | no |
 | volumes | Task volume definitions as list of maps | list | `<list>` | no |
 | vpc_id | The VPC ID where resources are created | string | - | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -12,16 +12,17 @@
 | deployment_minimum_healthy_percent | The lower limit (as a percentage of `desired_count`) of the number of tasks that must remain running and healthy in a service during a deployment | string | `100` | no |
 | desired_count | The number of instances of the task definition to place and keep running | string | `1` | no |
 | ecs_cluster_arn | The ARN of the ECS cluster where service will be provisioned | string | - | yes |
-| health_check_grace_period_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers. | string | `0` | no |
-| launch_type | The launch type on which to run your service. Valid values are EC2 and FARGATE | string | `FARGATE` | no |
+| health_check_grace_period_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers | string | `0` | no |
+| ignore_changes_task_definition | Whether to ignore changes in container definition and task definition in the ECS service | string | `true` | no |
+| launch_type | The launch type on which to run your service. Valid values are `EC2` and `FARGATE` | string | `FARGATE` | no |
 | name | Solution name, e.g. 'app' or 'cluster' | string | - | yes |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |
-| network_mode | The network mode to use for the task. This is required to be awsvpc for FARGATE `launch_type` | string | `awsvpc` | no |
+| network_mode | The network mode to use for the task. This is required to be awsvpc for `FARGATE` `launch_type` | string | `awsvpc` | no |
 | private_subnet_ids | Private subnet IDs | list | - | yes |
-| security_group_ids | Security group IDs to allow in Service network_configuration | list | - | yes |
+| security_group_ids | Security group IDs to allow in Service `network_configuration` | list | - | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | - | yes |
 | tags | Additional tags (e.g. `map('BusinessUnit`,`XYZ`) | map | `<map>` | no |
-| task_cpu | The number of CPU units used by the task. If using Fargate launch type `task_cpu` must match supported memory values (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | string | `256` | no |
+| task_cpu | The number of CPU units used by the task. If using `FARGATE` launch type `task_cpu` must match supported memory values (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | string | `256` | no |
 | task_memory | The amount of memory (in MiB) used by the task. If using Fargate launch type `task_memory` must match supported cpu value (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | string | `512` | no |
 | volumes | Task volume definitions as list of maps | list | `<list>` | no |
 | vpc_id | The VPC ID where resources are created | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "default_label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=0.1.6"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=0.2.1"
   attributes = "${var.attributes}"
   delimiter  = "${var.delimiter}"
   name       = "${var.name}"
@@ -9,7 +9,7 @@ module "default_label" {
 }
 
 module "task_label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=0.1.6"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=0.2.1"
   attributes = ["${compact(concat(var.attributes, list("task")))}"]
   delimiter  = "${var.delimiter}"
   name       = "${var.name}"
@@ -19,7 +19,7 @@ module "task_label" {
 }
 
 module "service_label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=0.1.6"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=0.2.1"
   attributes = ["${compact(concat(var.attributes, list("service")))}"]
   delimiter  = "${var.delimiter}"
   name       = "${var.name}"
@@ -29,7 +29,7 @@ module "service_label" {
 }
 
 module "exec_label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=0.1.6"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=0.2.1"
   attributes = ["${compact(concat(var.attributes, list("exec")))}"]
   delimiter  = "${var.delimiter}"
   name       = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -197,8 +197,4 @@ resource "aws_ecs_service" "default" {
     container_name   = "${var.container_name}"
     container_port   = "${var.container_port}"
   }
-
-  lifecycle {
-    ignore_changes = ["task_definition"]
-  }
 }

--- a/main.tf
+++ b/main.tf
@@ -153,9 +153,9 @@ resource "aws_iam_role_policy" "ecs_exec" {
 ## Security Groups
 resource "aws_security_group" "ecs_service" {
   vpc_id      = "${var.vpc_id}"
-  name        = "${module.default_label.id}"
-  description = "Allow ALL egress from ECS service."
-  tags        = "${module.default_label.tags}"
+  name        = "${module.service_label.id}"
+  description = "Allow ALL egress from ECS service"
+  tags        = "${module.service_label.tags}"
 }
 
 resource "aws_security_group_rule" "allow_all_egress" {

--- a/main.tf
+++ b/main.tf
@@ -197,4 +197,8 @@ resource "aws_ecs_service" "default" {
     container_name   = "${var.container_name}"
     container_port   = "${var.container_port}"
   }
+
+  lifecycle {
+    ignore_changes = ["task_definition"]
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "service_name" {
   description = "ECS Service name"
-  value       = "${aws_ecs_service.default.name}"
+  value       = "${element(coalescelist(aws_ecs_service.default.*.name, aws_ecs_service.ignore_changes_task_definition.*.name), 0)}"
 }
 
 output "service_role_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -67,24 +67,24 @@ variable "private_subnet_ids" {
 }
 
 variable "security_group_ids" {
-  description = "Security group IDs to allow in Service network_configuration"
+  description = "Security group IDs to allow in Service `network_configuration`"
   type        = "list"
 }
 
 variable "launch_type" {
   type        = "string"
-  description = "The launch type on which to run your service. Valid values are EC2 and FARGATE"
+  description = "The launch type on which to run your service. Valid values are `EC2` and `FARGATE`"
   default     = "FARGATE"
 }
 
 variable "network_mode" {
   type        = "string"
-  description = "The network mode to use for the task. This is required to be awsvpc for FARGATE `launch_type`"
+  description = "The network mode to use for the task. This is required to be awsvpc for `FARGATE` `launch_type`"
   default     = "awsvpc"
 }
 
 variable "task_cpu" {
-  description = "The number of CPU units used by the task. If using Fargate launch type `task_cpu` must match supported memory values (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size)"
+  description = "The number of CPU units used by the task. If using `FARGATE` launch type `task_cpu` must match supported memory values (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size)"
   default     = 256
 }
 
@@ -110,7 +110,7 @@ variable "deployment_minimum_healthy_percent" {
 
 variable "health_check_grace_period_seconds" {
   type        = "string"
-  description = "Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers."
+  description = "Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers"
   default     = 0
 }
 
@@ -118,4 +118,10 @@ variable "volumes" {
   type        = "list"
   description = "Task volume definitions as list of maps"
   default     = []
+}
+
+variable "ignore_changes_task_definition" {
+  type        = "string"
+  description = "Whether to ignore changes in container definition and task definition in the ECS service"
+  default     = "true"
 }


### PR DESCRIPTION
## what
* Fix name for `"aws_security_group" "ecs_service"`

## why
* Wrong label was used for `name` in `"aws_security_group" "ecs_service"`. Since the default label was used without any additional attributes to disambiguate the names, when deploying the cluster, there were errors that a Security Group with the same name already existed. For the Security Group for the ECS service, should use the `service_label`