### PR TITLE
feat: Allow configuration of auto assign public IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 ## Usage
 
 
+**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
+Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/releases).
+
+
+
 For a complete example, see [examples/complete](examples/complete)
 
 ```hcl
@@ -147,6 +152,7 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | alb_target_group_arn | The ALB target group ARN for the ECS service | string | - | yes |
+| assign_public_ip | Assign a public IP address to the ENI (Fargate launch type only). Valid values are true or false. Default false. | string | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | container_definition_json | The JSON of the task container definition | string | - | yes |
 | container_name | The name of the container in task definition to associate with the load balancer | string | - | yes |
@@ -162,9 +168,9 @@ Available targets:
 | name | Solution name, e.g. 'app' or 'cluster' | string | - | yes |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |
 | network_mode | The network mode to use for the task. This is required to be awsvpc for `FARGATE` `launch_type` | string | `awsvpc` | no |
-| private_subnet_ids | Private subnet IDs | list | - | yes |
 | security_group_ids | Security group IDs to allow in Service `network_configuration` | list | - | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | - | yes |
+| subnet_ids | Subnet IDs | list | - | yes |
 | tags | Additional tags (e.g. `map('BusinessUnit`,`XYZ`) | map | `<map>` | no |
 | task_cpu | The number of CPU units used by the task. If using `FARGATE` launch type `task_cpu` must match supported memory values (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | string | `256` | no |
 | task_memory | The amount of memory (in MiB) used by the task. If using Fargate launch type `task_memory` must match supported cpu value (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | string | `512` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,6 +3,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | alb_target_group_arn | The ALB target group ARN for the ECS service | string | - | yes |
+| assign_public_ip | Assign a public IP address to the ENI (Fargate launch type only). Valid values are true or false. Default false. | string | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | container_definition_json | The JSON of the task container definition | string | - | yes |
 | container_name | The name of the container in task definition to associate with the load balancer | string | - | yes |
@@ -18,9 +19,9 @@
 | name | Solution name, e.g. 'app' or 'cluster' | string | - | yes |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |
 | network_mode | The network mode to use for the task. This is required to be awsvpc for `FARGATE` `launch_type` | string | `awsvpc` | no |
-| private_subnet_ids | Private subnet IDs | list | - | yes |
 | security_group_ids | Security group IDs to allow in Service `network_configuration` | list | - | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | - | yes |
+| subnet_ids | Subnet IDs | list | - | yes |
 | tags | Additional tags (e.g. `map('BusinessUnit`,`XYZ`) | map | `<map>` | no |
 | task_cpu | The number of CPU units used by the task. If using `FARGATE` launch type `task_cpu` must match supported memory values (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | string | `256` | no |
 | task_memory | The amount of memory (in MiB) used by the task. If using Fargate launch type `task_memory` must match supported cpu value (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | string | `512` | no |

--- a/main.tf
+++ b/main.tf
@@ -189,8 +189,9 @@ resource "aws_ecs_service" "ignore_changes_task_definition" {
   tags                               = "${module.default_label.tags}"
 
   network_configuration {
-    security_groups = ["${var.security_group_ids}", "${aws_security_group.ecs_service.id}"]
-    subnets         = ["${var.private_subnet_ids}"]
+    security_groups  = ["${var.security_group_ids}", "${aws_security_group.ecs_service.id}"]
+    subnets          = ["${var.subnet_ids}"]
+    assign_public_ip = "${var.assign_public_ip}"
   }
 
   load_balancer {
@@ -217,8 +218,9 @@ resource "aws_ecs_service" "default" {
   tags                               = "${module.default_label.tags}"
 
   network_configuration {
-    security_groups = ["${var.security_group_ids}", "${aws_security_group.ecs_service.id}"]
-    subnets         = ["${var.private_subnet_ids}"]
+    security_groups  = ["${var.security_group_ids}", "${aws_security_group.ecs_service.id}"]
+    subnets          = ["${var.subnet_ids}"]
+    assign_public_ip = "${var.assign_public_ip}"
   }
 
   load_balancer {

--- a/variables.tf
+++ b/variables.tf
@@ -61,8 +61,8 @@ variable "container_port" {
   default     = 80
 }
 
-variable "private_subnet_ids" {
-  description = "Private subnet IDs"
+variable "subnet_ids" {
+  description = "Subnet IDs"
   type        = "list"
 }
 
@@ -124,4 +124,10 @@ variable "ignore_changes_task_definition" {
   type        = "string"
   description = "Whether to ignore changes in container definition and task definition in the ECS service"
   default     = "true"
+}
+
+variable "assign_public_ip" {
+  type        = "string"
+  default     = "false"
+  description = "Assign a public IP address to the ENI (Fargate launch type only). Valid values are true or false. Default false."
 }


### PR DESCRIPTION
Add `assign_public_ip` variable to allow configuring it. 
Rename variable `private_subnet_ids` to `subnet_ids` because it was misleading - public subnet ids can also be set here instead.

(Ref: https://www.terraform.io/docs/providers/aws/r/ecs_service.html#network_configuration-1)