### PR TITLE
Add exec outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,11 +181,15 @@ Available targets:
 
 | Name | Description |
 |------|-------------|
+| ecs_exec_role_policy_id | The role policy ID, in the form of role_name:role_policy_name. |
+| ecs_exec_role_policy_name | The name of the policy. |
 | service_name | ECS Service name |
 | service_role_arn | ECS Service role ARN |
 | service_security_group_id | Security Group ID of the ECS task |
 | task_definition_family | ECS task definition family |
 | task_definition_revision | ECS task definition revision |
+| task_exec_role_arn | ECS Task exec role arn |
+| task_exec_role_name | ECS Task exec role name |
 | task_role_arn | ECS Task role ARN |
 | task_role_name | ECS Task role name |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -32,11 +32,15 @@
 
 | Name | Description |
 |------|-------------|
+| ecs_exec_role_policy_id | The role policy ID, in the form of role_name:role_policy_name. |
+| ecs_exec_role_policy_name | The name of the policy. |
 | service_name | ECS Service name |
 | service_role_arn | ECS Service role ARN |
 | service_security_group_id | Security Group ID of the ECS task |
 | task_definition_family | ECS task definition family |
 | task_definition_revision | ECS task definition revision |
+| task_exec_role_arn | ECS Task exec role arn |
+| task_exec_role_name | ECS Task exec role name |
 | task_role_arn | ECS Task role ARN |
 | task_role_name | ECS Task role name |
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -55,5 +55,5 @@ module "alb_service_task" {
   launch_type               = "FARGATE"
   vpc_id                    = "xxxxxxx"
   security_group_ids        = ["xxxxx", "yyyyy"]
-  private_subnet_ids        = ["xxxxx", "yyyyy", "zzzzz"]
+  subnet_ids                = ["xxxxx", "yyyyy", "zzzzz"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,13 @@
+output "ecs_exec_role_policy_id" {
+  description = "The role policy ID, in the form of role_name:role_policy_name."
+  value = "${aws_iam_role_policy.ecs_exec.id}"
+}
+
+output "ecs_exec_role_policy_name" {
+  description = "The name of the policy."
+  value = "${aws_iam_role_policy.ecs_exec.name}"
+}
+
 output "service_name" {
   description = "ECS Service name"
   value       = "${element(coalescelist(aws_ecs_service.default.*.name, aws_ecs_service.ignore_changes_task_definition.*.name), 0)}"
@@ -6,6 +16,16 @@ output "service_name" {
 output "service_role_arn" {
   description = "ECS Service role ARN"
   value       = "${aws_iam_role.ecs_service.arn}"
+}
+
+output "task_exec_role_name" {
+  description = "ECS Task exec role name"
+  value       = "${aws_iam_role.ecs_exec.name}"
+}
+
+output "task_exec_role_arn" {
+  description = "ECS Task exec role arn"
+  value       = "${aws_iam_role.ecs_exec.arn}"
 }
 
 output "task_role_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,10 +1,10 @@
 output "ecs_exec_role_policy_id" {
-  description = "The role policy ID, in the form of role_name:role_policy_name."
+  description = "The ECS service role policy ID, in the form of role_name:role_policy_name"
   value       = "${aws_iam_role_policy.ecs_exec.id}"
 }
 
 output "ecs_exec_role_policy_name" {
-  description = "The name of the policy."
+  description = "ECS service role name"
   value       = "${aws_iam_role_policy.ecs_exec.name}"
 }
 
@@ -19,12 +19,12 @@ output "service_role_arn" {
 }
 
 output "task_exec_role_name" {
-  description = "ECS Task exec role name"
+  description = "ECS Task role name"
   value       = "${aws_iam_role.ecs_exec.name}"
 }
 
 output "task_exec_role_arn" {
-  description = "ECS Task exec role arn"
+  description = "ECS Task exec role ARN"
   value       = "${aws_iam_role.ecs_exec.arn}"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,11 @@
 output "ecs_exec_role_policy_id" {
   description = "The role policy ID, in the form of role_name:role_policy_name."
-  value = "${aws_iam_role_policy.ecs_exec.id}"
+  value       = "${aws_iam_role_policy.ecs_exec.id}"
 }
 
 output "ecs_exec_role_policy_name" {
   description = "The name of the policy."
-  value = "${aws_iam_role_policy.ecs_exec.name}"
+  value       = "${aws_iam_role_policy.ecs_exec.name}"
 }
 
 output "service_name" {


### PR DESCRIPTION
The task exec outputs are needed to add to the policy for SSM secrets usage and likely other things.