### PR TITLE
Add deployment_controller to ignored service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -188,6 +188,10 @@ resource "aws_ecs_service" "ignore_changes_task_definition" {
   cluster                            = "${var.ecs_cluster_arn}"
   tags                               = "${module.default_label.tags}"
 
+  deployment_controller {
+    type = "${var.deployment_controller_type}"
+  }
+
   network_configuration {
     security_groups  = ["${var.security_group_ids}", "${aws_security_group.ecs_service.id}"]
     subnets          = ["${var.subnet_ids}"]


### PR DESCRIPTION
#28 added the controller to only one of the services. The service is duplicated so it isn't applying in all scenarios.

@aknysh @osterman 