### PR TITLE
Add support for multiple load_balancer configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,6 @@ export README_DEPS ?= docs/targets.md docs/terraform.md
 
 lint:
 	$(SELF) terraform/install terraform/get-modules terraform/get-plugins terraform/lint terraform/validate
+
+example:
+	@cd examples/complete && terraform init && terraform plan

--- a/README.md
+++ b/README.md
@@ -152,18 +152,17 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | alb_security_group | Security group of the ALB | string | - | yes |
-| alb_target_group_arn | The ALB target group ARN for the ECS service | string | - | yes |
 | assign_public_ip | Assign a public IP address to the ENI (Fargate launch type only). Valid values are true or false. Default false. | string | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | container_definition_json | The JSON of the task container definition | string | - | yes |
-| container_name | The name of the container in task definition to associate with the load balancer | string | - | yes |
-| container_port | The port on the container to associate with the load balancer | string | `80` | no |
+| container_port | The port on the container to allow via the ingress security group | string | `80` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | deployment_controller_type | Type of deployment controller. Valid values: `CODE_DEPLOY`, `ECS`. | string | `ECS` | no |
 | deployment_maximum_percent | The upper limit of the number of tasks (as a percentage of `desired_count`) that can be running in a service during a deployment | string | `200` | no |
 | deployment_minimum_healthy_percent | The lower limit (as a percentage of `desired_count`) of the number of tasks that must remain running and healthy in a service during a deployment | string | `100` | no |
 | desired_count | The number of instances of the task definition to place and keep running | string | `1` | no |
 | ecs_cluster_arn | The ARN of the ECS cluster where service will be provisioned | string | - | yes |
+| ecs_load_balancers | A list of load balancer config objects for the ECS service; see `load_balancer` docs https://www.terraform.io/docs/providers/aws/r/ecs_service.html | list | `<list>` | no |
 | health_check_grace_period_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers | string | `0` | no |
 | ignore_changes_task_definition | Whether to ignore changes in container definition and task definition in the ECS service | string | `true` | no |
 | launch_type | The launch type on which to run your service. Valid values are `EC2` and `FARGATE` | string | `FARGATE` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,18 +3,17 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | alb_security_group | Security group of the ALB | string | - | yes |
-| alb_target_group_arn | The ALB target group ARN for the ECS service | string | - | yes |
 | assign_public_ip | Assign a public IP address to the ENI (Fargate launch type only). Valid values are true or false. Default false. | string | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | container_definition_json | The JSON of the task container definition | string | - | yes |
-| container_name | The name of the container in task definition to associate with the load balancer | string | - | yes |
-| container_port | The port on the container to associate with the load balancer | string | `80` | no |
+| container_port | The port on the container to allow via the ingress security group | string | `80` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | deployment_controller_type | Type of deployment controller. Valid values: `CODE_DEPLOY`, `ECS`. | string | `ECS` | no |
 | deployment_maximum_percent | The upper limit of the number of tasks (as a percentage of `desired_count`) that can be running in a service during a deployment | string | `200` | no |
 | deployment_minimum_healthy_percent | The lower limit (as a percentage of `desired_count`) of the number of tasks that must remain running and healthy in a service during a deployment | string | `100` | no |
 | desired_count | The number of instances of the task definition to place and keep running | string | `1` | no |
 | ecs_cluster_arn | The ARN of the ECS cluster where service will be provisioned | string | - | yes |
+| ecs_load_balancers | A list of load balancer config objects for the ECS service; see `load_balancer` docs https://www.terraform.io/docs/providers/aws/r/ecs_service.html | list | `<list>` | no |
 | health_check_grace_period_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers | string | `0` | no |
 | ignore_changes_task_definition | Whether to ignore changes in container definition and task definition in the ECS service | string | `true` | no |
 | launch_type | The launch type on which to run your service. Valid values are `EC2` and `FARGATE` | string | `FARGATE` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "> 2.22.0"
+  version = ">= 2.22.0"
 }
 
 module "label" {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  version = "> 2.22.0"
+}
+
 module "label" {
   source    = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=master"
   namespace = "eg"
@@ -43,18 +47,79 @@ module "container_definition" {
   ]
 }
 
-module "alb_service_task" {
-  source                    = "git::https://github.com/cloudposse/terraform-aws-ecs-alb-service-task.git?ref=master"
+// ECS service not tied to load balancer configs
+module "alb_service_task_no_lb" {
+  source                    = "../../"
   namespace                 = "eg"
   stage                     = "staging"
   name                      = "app"
-  alb_target_group_arn      = "xxxxxxx"
   alb_security_group        = "xxxxxxx"
   container_definition_json = "${module.container_definition.json}"
-  container_name            = "${module.label.id}"
   ecs_cluster_arn           = "xxxxxxx"
   launch_type               = "FARGATE"
   vpc_id                    = "xxxxxxx"
   security_group_ids        = ["xxxxx", "yyyyy"]
   subnet_ids                = ["xxxxx", "yyyyy", "zzzzz"]
+
+  ignore_changes_task_definition = "true"
+}
+
+// ECS service ignoring task definition changes
+module "alb_service_task_ignore" {
+  source                    = "../../"
+  namespace                 = "eg"
+  stage                     = "staging"
+  name                      = "app"
+  alb_security_group        = "xxxxxxx"
+  container_definition_json = "${module.container_definition.json}"
+  ecs_cluster_arn           = "xxxxxxx"
+  launch_type               = "FARGATE"
+  vpc_id                    = "xxxxxxx"
+  security_group_ids        = ["xxxxx", "yyyyy"]
+  subnet_ids                = ["xxxxx", "yyyyy", "zzzzz"]
+
+  ignore_changes_task_definition = "true"
+
+  ecs_load_balancers = [
+    {
+      target_group_arn = "xxxxxxx"
+      container_name   = "${module.label.id}"
+      container_port   = "80"
+    },
+    {
+      target_group_arn = "yyyyy"
+      container_name   = "${module.label.id}"
+      container_port   = "8080"
+    },
+  ]
+}
+
+// Default ECS service
+module "alb_service_task" {
+  source                    = "../../"
+  namespace                 = "eg"
+  stage                     = "staging"
+  name                      = "app"
+  alb_security_group        = "xxxxxxx"
+  container_definition_json = "${module.container_definition.json}"
+  ecs_cluster_arn           = "xxxxxxx"
+  launch_type               = "FARGATE"
+  vpc_id                    = "xxxxxxx"
+  security_group_ids        = ["xxxxx", "yyyyy"]
+  subnet_ids                = ["xxxxx", "yyyyy", "zzzzz"]
+
+  ignore_changes_task_definition = "false"
+
+  ecs_load_balancers = [
+    {
+      target_group_arn = "xxxxxxx"
+      container_name   = "${module.label.id}"
+      container_port   = "80"
+    },
+    {
+      target_group_arn = "yyyyy"
+      container_name   = "${module.label.id}"
+      container_port   = "8080"
+    },
+  ]
 }

--- a/main.tf
+++ b/main.tf
@@ -194,6 +194,7 @@ resource "aws_ecs_service" "ignore_changes_task_definition" {
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
   health_check_grace_period_seconds  = "${var.health_check_grace_period_seconds}"
   launch_type                        = "${var.launch_type}"
+  load_balancer                      = "${var.ecs_load_balancers}"
   cluster                            = "${var.ecs_cluster_arn}"
   tags                               = "${module.default_label.tags}"
 
@@ -205,12 +206,6 @@ resource "aws_ecs_service" "ignore_changes_task_definition" {
     security_groups  = ["${var.security_group_ids}", "${aws_security_group.ecs_service.id}"]
     subnets          = ["${var.subnet_ids}"]
     assign_public_ip = "${var.assign_public_ip}"
-  }
-
-  load_balancer {
-    target_group_arn = "${var.alb_target_group_arn}"
-    container_name   = "${var.container_name}"
-    container_port   = "${var.container_port}"
   }
 
   lifecycle {
@@ -227,6 +222,7 @@ resource "aws_ecs_service" "default" {
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
   health_check_grace_period_seconds  = "${var.health_check_grace_period_seconds}"
   launch_type                        = "${var.launch_type}"
+  load_balancer                      = "${var.ecs_load_balancers}"
   cluster                            = "${var.ecs_cluster_arn}"
   tags                               = "${module.default_label.tags}"
 
@@ -238,11 +234,5 @@ resource "aws_ecs_service" "default" {
     security_groups  = ["${var.security_group_ids}", "${aws_security_group.ecs_service.id}"]
     subnets          = ["${var.subnet_ids}"]
     assign_public_ip = "${var.assign_public_ip}"
-  }
-
-  load_balancer {
-    target_group_arn = "${var.alb_target_group_arn}"
-    container_name   = "${var.container_name}"
-    container_port   = "${var.container_port}"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,11 +36,6 @@ variable "vpc_id" {
   description = "The VPC ID where resources are created"
 }
 
-variable "alb_target_group_arn" {
-  type        = "string"
-  description = "The ALB target group ARN for the ECS service"
-}
-
 variable "alb_security_group" {
   type        = "string"
   description = "Security group of the ALB"
@@ -51,18 +46,19 @@ variable "ecs_cluster_arn" {
   description = "The ARN of the ECS cluster where service will be provisioned"
 }
 
+variable "ecs_load_balancers" {
+  default     = []
+  type        = "list"
+  description = "A list of load balancer config objects for the ECS service; see `load_balancer` docs https://www.terraform.io/docs/providers/aws/r/ecs_service.html"
+}
+
 variable "container_definition_json" {
   type        = "string"
   description = "The JSON of the task container definition"
 }
 
-variable "container_name" {
-  type        = "string"
-  description = "The name of the container in task definition to associate with the load balancer"
-}
-
 variable "container_port" {
-  description = "The port on the container to associate with the load balancer"
+  description = "The port on the container to allow via the ingress security group"
   default     = 80
 }
 


### PR DESCRIPTION
❗️❗️❗️❗️  Breaking Change ❗️❗️❗️❗️

# what

As of AWS provider 2.22, multiple `load_balancer` configs are supported; see https://www.terraform.io/docs/providers/aws/r/ecs_service.html.

More details: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/register-multiple-targetgroups.html.

# why

We have a use case for using two target groups for a single service. AWS supports this, but this module limits it to 1.

For maximum compatibility, I added the ability to allow consumers to define their own ports, names, etc.