### PR TITLE
Adding the option to defina an empty ALB SGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Available targets:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| alb_security_group | Security group of the ALB | string | - | yes |
+| alb_security_group | Security group of the ALB | string | `` | no |
 | assign_public_ip | Assign a public IP address to the ENI (Fargate launch type only). Valid values are `true` or `false`. Default `false` | bool | `false` | no |
 | attributes | Additional attributes (_e.g._ "1") | list(string) | `<list>` | no |
 | container_definition_json | The JSON of the task container definition | string | - | yes |

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Available targets:
 | task_cpu | The number of CPU units used by the task. If using `FARGATE` launch type `task_cpu` must match supported memory values (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | number | `256` | no |
 | task_memory | The amount of memory (in MiB) used by the task. If using Fargate launch type `task_memory` must match supported cpu value (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | number | `512` | no |
 | task_placement_constraints | A set of placement constraints rules that are taken into consideration during task placement. Maximum number of placement_constraints is 10. See `placement_constraints` docs https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#placement-constraints-arguments | object | `<list>` | no |
+| use_alb_security_group | A flag to enable/disable adding the ingress rule to the ALB security group | bool | `false` | no |
 | volumes | Task volume definitions as list of configuration objects | object | `<list>` | no |
 | vpc_id | The VPC ID where resources are created | string | - | yes |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -2,7 +2,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| alb_security_group | Security group of the ALB | string | - | yes |
+| alb_security_group | Security group of the ALB | string | `` | no |
 | assign_public_ip | Assign a public IP address to the ENI (Fargate launch type only). Valid values are `true` or `false`. Default `false` | bool | `false` | no |
 | attributes | Additional attributes (_e.g._ "1") | list(string) | `<list>` | no |
 | container_definition_json | The JSON of the task container definition | string | - | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -35,6 +35,7 @@
 | task_cpu | The number of CPU units used by the task. If using `FARGATE` launch type `task_cpu` must match supported memory values (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | number | `256` | no |
 | task_memory | The amount of memory (in MiB) used by the task. If using Fargate launch type `task_memory` must match supported cpu value (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) | number | `512` | no |
 | task_placement_constraints | A set of placement constraints rules that are taken into consideration during task placement. Maximum number of placement_constraints is 10. See `placement_constraints` docs https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#placement-constraints-arguments | object | `<list>` | no |
+| use_alb_security_group | A flag to enable/disable adding the ingress rule to the ALB security group | bool | `false` | no |
 | volumes | Task volume definitions as list of configuration objects | object | `<list>` | no |
 | vpc_id | The VPC ID where resources are created | string | - | yes |
 

--- a/main.tf
+++ b/main.tf
@@ -222,8 +222,8 @@ resource "aws_security_group_rule" "allow_icmp_ingress" {
   security_group_id = join("", aws_security_group.ecs_service.*.id)
 }
 
-resource "aws_security_group_rule" "default" {
-  count                    = var.enabled && var.alb_security_group != "" ? 1 : 0
+resource "aws_security_group_rule" "alb" {
+  count                    = var.enabled && var.use_alb_security_group != "" ? 1 : 0
   type                     = "ingress"
   from_port                = 0
   to_port                  = var.container_port

--- a/main.tf
+++ b/main.tf
@@ -223,7 +223,7 @@ resource "aws_security_group_rule" "allow_icmp_ingress" {
 }
 
 resource "aws_security_group_rule" "alb" {
-  count                    = var.enabled && var.use_alb_security_group != "" ? 1 : 0
+  count                    = var.enabled && var.use_alb_security_group ? 1 : 0
   type                     = "ingress"
   from_port                = 0
   to_port                  = var.container_port

--- a/main.tf
+++ b/main.tf
@@ -222,8 +222,8 @@ resource "aws_security_group_rule" "allow_icmp_ingress" {
   security_group_id = join("", aws_security_group.ecs_service.*.id)
 }
 
-resource "aws_security_group_rule" "alb" {
-  count                    = var.enabled && var.alb_security_group == "" ? 1 : 0
+resource "aws_security_group_rule" "default" {
+  count                    = var.enabled && var.alb_security_group != "" ? 1 : 0
   type                     = "ingress"
   from_port                = 0
   to_port                  = var.container_port

--- a/main.tf
+++ b/main.tf
@@ -223,7 +223,7 @@ resource "aws_security_group_rule" "allow_icmp_ingress" {
 }
 
 resource "aws_security_group_rule" "alb" {
-  count                    = var.enabled ? 1 : 0
+  count                    = var.enabled && var.alb_security_group == "" ? 1 : 0
   type                     = "ingress"
   from_port                = 0
   to_port                  = var.container_port

--- a/variables.tf
+++ b/variables.tf
@@ -235,3 +235,9 @@ variable "service_registries" {
   description = "The service discovery registries for the service. The maximum number of service_registries blocks is 1. The currently supported service registry is Amazon Route 53 Auto Naming Service - `aws_service_discovery_service`; see `service_registries` docs https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries-1"
   default     = []
 }
+
+variable "use_alb_security_group" {
+  type        = bool
+  description = "A flag to enable/disable adding the ingress rule to the ALB security group"
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,7 @@ variable "vpc_id" {
 variable "alb_security_group" {
   type        = string
   description = "Security group of the ALB"
+  default     = ""
 }
 
 variable "ecs_cluster_arn" {


### PR DESCRIPTION
This option is for the cases where ECS launch type is EC2 and the network mode is host and there is no alb fronting the application.

One could argue that this module has morf so much that the `alb` in the name might or might not need to be there