### PR TITLE
Use old arn format

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Available targets:
 | task_placement_constraints | A set of placement constraints rules that are taken into consideration during task placement. Maximum number of placement_constraints is 10. See `placement_constraints` docs https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#placement-constraints-arguments | object | `<list>` | no |
 | use_alb_security_group | A flag to enable/disable adding the ingress rule to the ALB security group | bool | `false` | no |
 | use_nlb_cidr_blocks | A flag to enable/disable adding the NLB ingress rule to the security group | bool | `false` | no |
+| use\_old\_arn | A flag to enable/disable tagging the ecs resources that require the new arn format | `bool` | `false` | no |
 | volumes | Task volume definitions as list of configuration objects | object | `<list>` | no |
 | vpc_id | The VPC ID where resources are created | string | - | yes |
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Available targets:
 | task_placement_constraints | A set of placement constraints rules that are taken into consideration during task placement. Maximum number of placement_constraints is 10. See `placement_constraints` docs https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#placement-constraints-arguments | object | `<list>` | no |
 | use_alb_security_group | A flag to enable/disable adding the ingress rule to the ALB security group | bool | `false` | no |
 | use_nlb_cidr_blocks | A flag to enable/disable adding the NLB ingress rule to the security group | bool | `false` | no |
-| use\_old\_arn | A flag to enable/disable tagging the ecs resources that require the new arn format | `bool` | `false` | no |
+| use_old_arn | A flag to enable/disable tagging the ecs resources that require the new arn format | bool | `false` | no |
 | volumes | Task volume definitions as list of configuration objects | object | `<list>` | no |
 | vpc_id | The VPC ID where resources are created | string | - | yes |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -42,6 +42,7 @@
 | task_placement_constraints | A set of placement constraints rules that are taken into consideration during task placement. Maximum number of placement_constraints is 10. See `placement_constraints` docs https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#placement-constraints-arguments | object | `<list>` | no |
 | use_alb_security_group | A flag to enable/disable adding the ingress rule to the ALB security group | bool | `false` | no |
 | use_nlb_cidr_blocks | A flag to enable/disable adding the NLB ingress rule to the security group | bool | `false` | no |
+| use_old_arn | A flag to enable/disable tagging the ecs resources that require the new arn format | bool | `false` | no |
 | volumes | Task volume definitions as list of configuration objects | object | `<list>` | no |
 | vpc_id | The VPC ID where resources are created | string | - | yes |
 

--- a/main.tf
+++ b/main.tf
@@ -307,7 +307,7 @@ resource "aws_ecs_service" "ignore_changes_task_definition" {
 
   cluster        = var.ecs_cluster_arn
   propagate_tags = var.propagate_tags
-  tags           = module.default_label.tags
+  tags           = var.use_old_arn ? null : module.default_label.tags
 
   deployment_controller {
     type = var.deployment_controller_type
@@ -388,7 +388,7 @@ resource "aws_ecs_service" "default" {
 
   cluster        = var.ecs_cluster_arn
   propagate_tags = var.propagate_tags
-  tags           = module.default_label.tags
+  tags           = var.use_old_arn ? null : module.default_label.tags
 
   deployment_controller {
     type = var.deployment_controller_type

--- a/variables.tf
+++ b/variables.tf
@@ -281,3 +281,9 @@ variable "permissions_boundary" {
   description = "A permissions boundary ARN to apply to the 3 roles that are created."
   default     = ""
 }
+
+variable "use_old_arn" {
+  type        = bool
+  description = "A flag to enable/disable tagging the ecs resources that require the new arn format"
+  default     = false
+}


### PR DESCRIPTION
## what
If the old arn format is still used, then this module should not tag the service as that's not possible with the old arn.

## why
Fixes https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/issues/50

## references
N/A

