### PR TITLE
Added EFS volume config to ECR fargate task definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Available targets:
 | use\_alb\_security\_group | A flag to enable/disable adding the ingress rule to the ALB security group | `bool` | `false` | no |
 | use\_nlb\_cidr\_blocks | A flag to enable/disable adding the NLB ingress rule to the security group | `bool` | `false` | no |
 | use\_old\_arn | A flag to enable/disable tagging the ecs resources that require the new arn format | `bool` | `false` | no |
-| volumes | Task volume definitions as list of configuration objects | <pre>list(object({<br>    host_path = string<br>    name      = string<br>    docker_volume_configuration = list(object({<br>      autoprovision = bool<br>      driver        = string<br>      driver_opts   = map(string)<br>      labels        = map(string)<br>      scope         = string<br>    }))<br>  }))</pre> | `[]` | no |
+| volumes | Task volume definitions as list of configuration objects | <pre>list(object({<br>    host_path = string<br>    name      = string<br>    docker_volume_configuration = list(object({<br>      autoprovision = bool<br>      driver        = string<br>      driver_opts   = map(string)<br>      labels        = map(string)<br>      scope         = string<br>    }))<br>    efs_volume_configuration = list(object({<br>      file_system_id          = string<br>      root_directory          = string<br>      transit_encryption      = string<br>      transit_encryption_port = string<br>      authorization_config = list(object({<br>        access_point_id = string<br>        iam             = string<br>      }))<br>    }))<br>  }))</pre> | `[]` | no |
 | vpc\_id | The VPC ID where resources are created | `string` | n/a | yes |
 
 ## Outputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -62,7 +62,7 @@
 | use\_alb\_security\_group | A flag to enable/disable adding the ingress rule to the ALB security group | `bool` | `false` | no |
 | use\_nlb\_cidr\_blocks | A flag to enable/disable adding the NLB ingress rule to the security group | `bool` | `false` | no |
 | use\_old\_arn | A flag to enable/disable tagging the ecs resources that require the new arn format | `bool` | `false` | no |
-| volumes | Task volume definitions as list of configuration objects | <pre>list(object({<br>    host_path = string<br>    name      = string<br>    docker_volume_configuration = list(object({<br>      autoprovision = bool<br>      driver        = string<br>      driver_opts   = map(string)<br>      labels        = map(string)<br>      scope         = string<br>    }))<br>  }))</pre> | `[]` | no |
+| volumes | Task volume definitions as list of configuration objects | <pre>list(object({<br>    host_path = string<br>    name      = string<br>    docker_volume_configuration = list(object({<br>      autoprovision = bool<br>      driver        = string<br>      driver_opts   = map(string)<br>      labels        = map(string)<br>      scope         = string<br>    }))<br>    efs_volume_configuration = list(object({<br>      file_system_id          = string<br>      root_directory          = string<br>      transit_encryption      = string<br>      transit_encryption_port = string<br>      authorization_config = list(object({<br>        access_point_id = string<br>        iam             = string<br>      }))<br>    }))<br>  }))</pre> | `[]` | no |
 | vpc\_id | The VPC ID where resources are created | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,23 @@ resource "aws_ecs_task_definition" "default" {
           scope         = lookup(docker_volume_configuration.value, "scope", null)
         }
       }
+
+      dynamic "efs_volume_configuration" {
+        for_each = lookup(volume.value, "efs_volume_configuration", [])
+        content {
+          file_system_id          = lookup(efs_volume_configuration.value, "file_system_id", null)
+          root_directory          = lookup(efs_volume_configuration.value, "root_directory", null)
+          transit_encryption      = lookup(efs_volume_configuration.value, "transit_encryption", null)
+          transit_encryption_port = lookup(efs_volume_configuration.value, "transit_encryption_port", null)
+          dynamic "authorization_config" {
+            for_each = lookup(volume.value, "authorization_config", [])
+            content {
+              access_point_id = lookup(authorization_config.value, "access_point_id", null)
+              iam             = lookup(authorization_config.value, "iam", null)
+            }
+          }
+        }
+      }
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -205,13 +205,13 @@ variable "volumes" {
       scope         = string
     }))
     efs_volume_configuration = list(object({
-      file_system_id = string
-      root_directory = string
-      transit_encryption = string
+      file_system_id          = string
+      root_directory          = string
+      transit_encryption      = string
       transit_encryption_port = string
       authorization_config = list(object({
         access_point_id = string
-        iam = string
+        iam             = string
       }))
     }))
   }))

--- a/variables.tf
+++ b/variables.tf
@@ -204,6 +204,16 @@ variable "volumes" {
       labels        = map(string)
       scope         = string
     }))
+    efs_volume_configuration = list(object({
+      file_system_id = string
+      root_directory = string
+      transit_encryption = string
+      transit_encryption_port = string
+      authorization_config = list(object({
+        access_point_id = string
+        iam = string
+      }))
+    }))
   }))
   description = "Task volume definitions as list of configuration objects"
   default     = []


### PR DESCRIPTION
## what
* Recently AWS announced support for EFS volumes in ECS fargate. This pull request adds those options to the task defenition.

## why
* To reflect the current ecr task definition volume configuration options

## references
* [ecs_task_definition.html#efs-volume-configuration-arguments](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#efs-volume-configuration-arguments)
* [Amazon ECS and AWS Fargate support for Amazon EFS File Systems now generally available](https://aws.amazon.com/about-aws/whats-new/2020/04/amazon-ecs-aws-fargate-support-amazon-efs-filesystems-generally-available/)

