### PR TITLE
Add example to add iam policies to task role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -205,7 +205,8 @@ data "aws_iam_policy_document" "ecs_exec" {
       "ecr:BatchGetImage",
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
-      "logs:PutLogEvents"
+      "logs:PutLogEvents",
+      "secretsmanager:GetSecretValue"
     ]
   }
 }


### PR DESCRIPTION
## what
Add permission to get SecretsManager values form exec task

## why
Needed for Fargate to access SecretsManager when task is instantiated by service

## references
should close #67 

