### PR TITLE
Update provider pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,17 +221,17 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.42 |
-| local | ~> 1.3 |
-| null | ~> 2.0 |
-| template | ~> 2.0 |
+| terraform | >= 0.12 |
+| aws | >= 2.0 |
+| local | >= 1.3 |
+| null | >= 2.0 |
+| template | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.42 |
+| aws | >= 2.0 |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,17 +3,17 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.42 |
-| local | ~> 1.3 |
-| null | ~> 2.0 |
-| template | ~> 2.0 |
+| terraform | >= 0.12 |
+| aws | >= 2.0 |
+| local | >= 1.3 |
+| null | >= 2.0 |
+| template | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.42 |
+| aws | >= 2.0 |
 
 ## Inputs
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,10 +1,21 @@
 terraform {
-  required_version = "~> 0.12.0"
-
+  required_version = ">= 0.12"
   required_providers {
-    aws      = "~> 2.0"
-    template = "~> 2.0"
-    null     = "~> 2.0"
-    local    = "~> 1.3"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.3"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,22 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
-
+  required_version = ">= 0.12"
   required_providers {
-    aws      = "~> 2.42"
-    template = "~> 2.0"
-    null     = "~> 2.0"
-    local    = "~> 1.3"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.3"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
   }
 }
+


### PR DESCRIPTION
## what
* Update to accept 0.13 and aws provider 3

## why
* To make provider versions compatible
