### PR TITLE
Expose ARN for service so we don't have to manually construct it

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,25 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 
 
+## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
+
+Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
+
+| Benchmark | Description |
+|--------|---------------|
+| [![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-alb-service-task/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-alb-service-task&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
+| [![CIS KUBERNETES](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-alb-service-task/cis_kubernetes)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-alb-service-task&benchmark=CIS+KUBERNETES+V1.5) | Center for Internet Security, KUBERNETES Compliance |
+| [![CIS AWS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-alb-service-task/cis_aws)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-alb-service-task&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance |
+| [![CIS AZURE](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-alb-service-task/cis_azure)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-alb-service-task&benchmark=CIS+AZURE+V1.1) | Center for Internet Security, AZURE Compliance |
+| [![PCI-DSS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-alb-service-task/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-alb-service-task&benchmark=PCI-DSS+V3.2) | Payment Card Industry Data Security Standards Compliance |
+| [![NIST-800-53](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-alb-service-task/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-alb-service-task&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
+| [![ISO27001](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-alb-service-task/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-alb-service-task&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
+| [![SOC2](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-alb-service-task/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-alb-service-task&benchmark=SOC2)| Service Organization Control 2 Compliance |
+| [![CIS GCP](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-alb-service-task/cis_gcp)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-alb-service-task&benchmark=CIS+GCP+V1.1) | Center for Internet Security, GCP Compliance |
+| [![HIPAA](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-alb-service-task/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-alb-service-task&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
+
+
+
 ## Usage
 
 
@@ -310,6 +329,7 @@ Available targets:
 |------|-------------|
 | ecs\_exec\_role\_policy\_id | The ECS service role policy ID, in the form of `role_name:role_policy_name` |
 | ecs\_exec\_role\_policy\_name | ECS service role name |
+| service\_arn | ECS Service ARN |
 | service\_name | ECS Service name |
 | service\_role\_arn | ECS Service role ARN |
 | service\_security\_group\_id | Security Group ID of the ECS task |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -81,6 +81,7 @@
 |------|-------------|
 | ecs\_exec\_role\_policy\_id | The ECS service role policy ID, in the form of `role_name:role_policy_name` |
 | ecs\_exec\_role\_policy\_name | ECS service role name |
+| service\_arn | ECS Service ARN |
 | service\_name | ECS Service name |
 | service\_role\_arn | ECS Service role ARN |
 | service\_security\_group\_id | Security Group ID of the ECS task |

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "service_name" {
   value       = join("", aws_ecs_service.default.*.name) != "" ? join("", aws_ecs_service.default.*.name) : join("", aws_ecs_service.ignore_changes_task_definition.*.name)
 }
 
+output "service_arn" {
+  description = "ECS Service ARN"
+  value       = join("", aws_ecs_service.default.*.arn) != "" ? join("", aws_ecs_service.default.*.arn) : join("", aws_ecs_service.ignore_changes_task_definition.*.arn)
+}
+
 output "service_role_arn" {
   description = "ECS Service role ARN"
   value       = join("", aws_iam_role.ecs_service.*.arn)

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "service_name" {
 
 output "service_arn" {
   description = "ECS Service ARN"
-  value       = join("", aws_ecs_service.default.*.arn) != "" ? join("", aws_ecs_service.default.*.arn) : join("", aws_ecs_service.ignore_changes_task_definition.*.arn)
+  value       = join("", aws_ecs_service.default.*.id) != "" ? join("", aws_ecs_service.default.*.id) : join("", aws_ecs_service.ignore_changes_task_definition.*.id)
 }
 
 output "service_role_arn" {


### PR DESCRIPTION
## what
* Expose ARN for service so we don't have to manually construct it

## why
* Ease of use and preventing user error


