### PR TITLE
Fix HCL spacing in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,8 +520,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Sarkis Varozian][sarkis_avatar]][sarkis_homepage]<br/>[Sarkis Varozian][sarkis_homepage] | [![Chris Weyl][rsrchboy_avatar]][rsrchboy_homepage]<br/>[Chris Weyl][rsrchboy_homepage] |
-|---|---|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Sarkis Varozian][sarkis_avatar]][sarkis_homepage]<br/>[Sarkis Varozian][sarkis_homepage] | [![Chris Weyl][rsrchboy_avatar]][rsrchboy_homepage]<br/>[Chris Weyl][rsrchboy_homepage] | [![RB][nitrocode_avatar]][nitrocode_homepage]<br/>[RB][nitrocode_homepage] |
+|---|---|---|---|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
@@ -534,6 +534,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [sarkis_avatar]: https://img.cloudposse.com/150x150/https://github.com/sarkis.png
   [rsrchboy_homepage]: https://github.com/rsrchboy
   [rsrchboy_avatar]: https://img.cloudposse.com/150x150/https://github.com/rsrchboy.png
+  [nitrocode_homepage]: https://github.com/nitrocode
+  [nitrocode_avatar]: https://img.cloudposse.com/150x150/https://github.com/nitrocode.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.md
+++ b/README.md
@@ -100,95 +100,95 @@ For a complete example, see [examples/complete](examples/complete).
 For automated test of the complete example using `bats` and `Terratest`, see [test](test).
 
 ```hcl
-  provider "aws" {
-    region = var.region
-  }
+provider "aws" {
+  region = var.region
+}
 
-  module "label" {
-    source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.15.0"
-    namespace  = var.namespace
-    name       = var.name
-    stage      = var.stage
-    delimiter  = var.delimiter
-    attributes = var.attributes
-    tags       = var.tags
-  }
+module "label" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.15.0"
+  namespace  = var.namespace
+  name       = var.name
+  stage      = var.stage
+  delimiter  = var.delimiter
+  attributes = var.attributes
+  tags       = var.tags
+}
 
-  module "vpc" {
-    source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
-    namespace  = var.namespace
-    stage      = var.stage
-    name       = var.name
-    delimiter  = var.delimiter
-    attributes = var.attributes
-    cidr_block = var.vpc_cidr_block
-    tags       = var.tags
-  }
+module "vpc" {
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  delimiter  = var.delimiter
+  attributes = var.attributes
+  cidr_block = var.vpc_cidr_block
+  tags       = var.tags
+}
 
-  module "subnets" {
-    source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.1"
-    availability_zones   = var.availability_zones
-    namespace            = var.namespace
-    stage                = var.stage
-    name                 = var.name
-    attributes           = var.attributes
-    delimiter            = var.delimiter
-    vpc_id               = module.vpc.vpc_id
-    igw_id               = module.vpc.igw_id
-    cidr_block           = module.vpc.vpc_cidr_block
-    nat_gateway_enabled  = true
-    nat_instance_enabled = false
-    tags                 = var.tags
-  }
+module "subnets" {
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.1"
+  availability_zones   = var.availability_zones
+  namespace            = var.namespace
+  stage                = var.stage
+  name                 = var.name
+  attributes           = var.attributes
+  delimiter            = var.delimiter
+  vpc_id               = module.vpc.vpc_id
+  igw_id               = module.vpc.igw_id
+  cidr_block           = module.vpc.vpc_cidr_block
+  nat_gateway_enabled  = true
+  nat_instance_enabled = false
+  tags                 = var.tags
+}
 
-  resource "aws_ecs_cluster" "default" {
-    name = module.label.id
-    tags = module.label.tags
-  }
+resource "aws_ecs_cluster" "default" {
+  name = module.label.id
+  tags = module.label.tags
+}
 
-  module "container_definition" {
-    source                       = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=tags/0.21.0"
-    container_name               = var.container_name
-    container_image              = var.container_image
-    container_memory             = var.container_memory
-    container_memory_reservation = var.container_memory_reservation
-    container_cpu                = var.container_cpu
-    essential                    = var.container_essential
-    readonly_root_filesystem     = var.container_readonly_root_filesystem
-    environment                  = var.container_environment
-    port_mappings                = var.container_port_mappings
-    log_configuration            = var.container_log_configuration
-  }
+module "container_definition" {
+  source                       = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=tags/0.21.0"
+  container_name               = var.container_name
+  container_image              = var.container_image
+  container_memory             = var.container_memory
+  container_memory_reservation = var.container_memory_reservation
+  container_cpu                = var.container_cpu
+  essential                    = var.container_essential
+  readonly_root_filesystem     = var.container_readonly_root_filesystem
+  environment                  = var.container_environment
+  port_mappings                = var.container_port_mappings
+  log_configuration            = var.container_log_configuration
+}
 
-  module "ecs_alb_service_task" {
-    source = "cloudposse/ecs-alb-service-task/aws"
-    # Cloud Posse recommends pinning every module to a specific version
-    # version = "x.x.x"
-    namespace                          = var.namespace
-    stage                              = var.stage
-    name                               = var.name
-    attributes                         = var.attributes
-    delimiter                          = var.delimiter
-    alb_security_group                 = module.vpc.vpc_default_security_group_id
-    container_definition_json          = module.container_definition.json
-    ecs_cluster_arn                    = aws_ecs_cluster.default.arn
-    launch_type                        = var.ecs_launch_type
-    vpc_id                             = module.vpc.vpc_id
-    security_group_ids                 = [module.vpc.vpc_default_security_group_id]
-    subnet_ids                         = module.subnets.public_subnet_ids
-    tags                               = var.tags
-    ignore_changes_task_definition     = var.ignore_changes_task_definition
-    network_mode                       = var.network_mode
-    assign_public_ip                   = var.assign_public_ip
-    propagate_tags                     = var.propagate_tags
-    health_check_grace_period_seconds  = var.health_check_grace_period_seconds
-    deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-    deployment_maximum_percent         = var.deployment_maximum_percent
-    deployment_controller_type         = var.deployment_controller_type
-    desired_count                      = var.desired_count
-    task_memory                        = var.task_memory
-    task_cpu                           = var.task_cpu
-  }
+module "ecs_alb_service_task" {
+  source = "cloudposse/ecs-alb-service-task/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version = "x.x.x"
+  namespace                          = var.namespace
+  stage                              = var.stage
+  name                               = var.name
+  attributes                         = var.attributes
+  delimiter                          = var.delimiter
+  alb_security_group                 = module.vpc.vpc_default_security_group_id
+  container_definition_json          = module.container_definition.json
+  ecs_cluster_arn                    = aws_ecs_cluster.default.arn
+  launch_type                        = var.ecs_launch_type
+  vpc_id                             = module.vpc.vpc_id
+  security_group_ids                 = [module.vpc.vpc_default_security_group_id]
+  subnet_ids                         = module.subnets.public_subnet_ids
+  tags                               = var.tags
+  ignore_changes_task_definition     = var.ignore_changes_task_definition
+  network_mode                       = var.network_mode
+  assign_public_ip                   = var.assign_public_ip
+  propagate_tags                     = var.propagate_tags
+  health_check_grace_period_seconds  = var.health_check_grace_period_seconds
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_controller_type         = var.deployment_controller_type
+  desired_count                      = var.desired_count
+  task_memory                        = var.task_memory
+  task_cpu                           = var.task_cpu
+}
 ```
 
 The `container_image` in the `container_definition` module is the Docker image used to start a container.
@@ -262,6 +262,28 @@ Available targets:
 | Name | Version |
 |------|---------|
 | aws | >= 2.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| exec_label | cloudposse/label/null | 0.24.1 |
+| service_label | cloudposse/label/null | 0.24.1 |
+| task_label | cloudposse/label/null | 0.24.1 |
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_ecs_service](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/ecs_service) |
+| [aws_ecs_task_definition](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/ecs_task_definition) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_role) |
+| [aws_iam_role_policy](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_role_policy) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_role_policy_attachment) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group) |
+| [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group_rule) |
 
 ## Inputs
 
@@ -342,7 +364,6 @@ Available targets:
 | task\_role\_arn | ECS Task role ARN |
 | task\_role\_id | ECS Task role id |
 | task\_role\_name | ECS Task role name |
-
 <!-- markdownlint-restore -->
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -193,3 +193,5 @@ contributors:
   github: sarkis
 - name: Chris Weyl
   github: rsrchboy
+- name: RB
+  github: nitrocode

--- a/README.yaml
+++ b/README.yaml
@@ -50,95 +50,95 @@ usage: |2-
   For automated test of the complete example using `bats` and `Terratest`, see [test](test).
 
   ```hcl
-    provider "aws" {
-      region = var.region
-    }
+  provider "aws" {
+    region = var.region
+  }
 
-    module "label" {
-      source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.15.0"
-      namespace  = var.namespace
-      name       = var.name
-      stage      = var.stage
-      delimiter  = var.delimiter
-      attributes = var.attributes
-      tags       = var.tags
-    }
+  module "label" {
+    source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.15.0"
+    namespace  = var.namespace
+    name       = var.name
+    stage      = var.stage
+    delimiter  = var.delimiter
+    attributes = var.attributes
+    tags       = var.tags
+  }
 
-    module "vpc" {
-      source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
-      namespace  = var.namespace
-      stage      = var.stage
-      name       = var.name
-      delimiter  = var.delimiter
-      attributes = var.attributes
-      cidr_block = var.vpc_cidr_block
-      tags       = var.tags
-    }
+  module "vpc" {
+    source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
+    namespace  = var.namespace
+    stage      = var.stage
+    name       = var.name
+    delimiter  = var.delimiter
+    attributes = var.attributes
+    cidr_block = var.vpc_cidr_block
+    tags       = var.tags
+  }
 
-    module "subnets" {
-      source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.1"
-      availability_zones   = var.availability_zones
-      namespace            = var.namespace
-      stage                = var.stage
-      name                 = var.name
-      attributes           = var.attributes
-      delimiter            = var.delimiter
-      vpc_id               = module.vpc.vpc_id
-      igw_id               = module.vpc.igw_id
-      cidr_block           = module.vpc.vpc_cidr_block
-      nat_gateway_enabled  = true
-      nat_instance_enabled = false
-      tags                 = var.tags
-    }
+  module "subnets" {
+    source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.1"
+    availability_zones   = var.availability_zones
+    namespace            = var.namespace
+    stage                = var.stage
+    name                 = var.name
+    attributes           = var.attributes
+    delimiter            = var.delimiter
+    vpc_id               = module.vpc.vpc_id
+    igw_id               = module.vpc.igw_id
+    cidr_block           = module.vpc.vpc_cidr_block
+    nat_gateway_enabled  = true
+    nat_instance_enabled = false
+    tags                 = var.tags
+  }
 
-    resource "aws_ecs_cluster" "default" {
-      name = module.label.id
-      tags = module.label.tags
-    }
+  resource "aws_ecs_cluster" "default" {
+    name = module.label.id
+    tags = module.label.tags
+  }
 
-    module "container_definition" {
-      source                       = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=tags/0.21.0"
-      container_name               = var.container_name
-      container_image              = var.container_image
-      container_memory             = var.container_memory
-      container_memory_reservation = var.container_memory_reservation
-      container_cpu                = var.container_cpu
-      essential                    = var.container_essential
-      readonly_root_filesystem     = var.container_readonly_root_filesystem
-      environment                  = var.container_environment
-      port_mappings                = var.container_port_mappings
-      log_configuration            = var.container_log_configuration
-    }
+  module "container_definition" {
+    source                       = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=tags/0.21.0"
+    container_name               = var.container_name
+    container_image              = var.container_image
+    container_memory             = var.container_memory
+    container_memory_reservation = var.container_memory_reservation
+    container_cpu                = var.container_cpu
+    essential                    = var.container_essential
+    readonly_root_filesystem     = var.container_readonly_root_filesystem
+    environment                  = var.container_environment
+    port_mappings                = var.container_port_mappings
+    log_configuration            = var.container_log_configuration
+  }
 
-    module "ecs_alb_service_task" {
-      source = "cloudposse/ecs-alb-service-task/aws"
-      # Cloud Posse recommends pinning every module to a specific version
-      # version = "x.x.x"
-      namespace                          = var.namespace
-      stage                              = var.stage
-      name                               = var.name
-      attributes                         = var.attributes
-      delimiter                          = var.delimiter
-      alb_security_group                 = module.vpc.vpc_default_security_group_id
-      container_definition_json          = module.container_definition.json
-      ecs_cluster_arn                    = aws_ecs_cluster.default.arn
-      launch_type                        = var.ecs_launch_type
-      vpc_id                             = module.vpc.vpc_id
-      security_group_ids                 = [module.vpc.vpc_default_security_group_id]
-      subnet_ids                         = module.subnets.public_subnet_ids
-      tags                               = var.tags
-      ignore_changes_task_definition     = var.ignore_changes_task_definition
-      network_mode                       = var.network_mode
-      assign_public_ip                   = var.assign_public_ip
-      propagate_tags                     = var.propagate_tags
-      health_check_grace_period_seconds  = var.health_check_grace_period_seconds
-      deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-      deployment_maximum_percent         = var.deployment_maximum_percent
-      deployment_controller_type         = var.deployment_controller_type
-      desired_count                      = var.desired_count
-      task_memory                        = var.task_memory
-      task_cpu                           = var.task_cpu
-    }
+  module "ecs_alb_service_task" {
+    source = "cloudposse/ecs-alb-service-task/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version = "x.x.x"
+    namespace                          = var.namespace
+    stage                              = var.stage
+    name                               = var.name
+    attributes                         = var.attributes
+    delimiter                          = var.delimiter
+    alb_security_group                 = module.vpc.vpc_default_security_group_id
+    container_definition_json          = module.container_definition.json
+    ecs_cluster_arn                    = aws_ecs_cluster.default.arn
+    launch_type                        = var.ecs_launch_type
+    vpc_id                             = module.vpc.vpc_id
+    security_group_ids                 = [module.vpc.vpc_default_security_group_id]
+    subnet_ids                         = module.subnets.public_subnet_ids
+    tags                               = var.tags
+    ignore_changes_task_definition     = var.ignore_changes_task_definition
+    network_mode                       = var.network_mode
+    assign_public_ip                   = var.assign_public_ip
+    propagate_tags                     = var.propagate_tags
+    health_check_grace_period_seconds  = var.health_check_grace_period_seconds
+    deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+    deployment_maximum_percent         = var.deployment_maximum_percent
+    deployment_controller_type         = var.deployment_controller_type
+    desired_count                      = var.desired_count
+    task_memory                        = var.task_memory
+    task_cpu                           = var.task_cpu
+  }
   ```
 
   The `container_image` in the `container_definition` module is the Docker image used to start a container.

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -15,6 +15,28 @@
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| exec_label | cloudposse/label/null | 0.24.1 |
+| service_label | cloudposse/label/null | 0.24.1 |
+| task_label | cloudposse/label/null | 0.24.1 |
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_ecs_service](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/ecs_service) |
+| [aws_ecs_task_definition](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/ecs_task_definition) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_role) |
+| [aws_iam_role_policy](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_role_policy) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_role_policy_attachment) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group) |
+| [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group_rule) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -94,5 +116,4 @@
 | task\_role\_arn | ECS Task role ARN |
 | task\_role\_id | ECS Task role id |
 | task\_role\_name | ECS Task role name |
-
 <!-- markdownlint-restore -->


### PR DESCRIPTION
## what
Fixed the HCL spacing in the `README.md` example

## why
Because it was annoying to fix the spacing when copying and pasting

## references
N/A

