### PR TITLE
Set enable_icmp_rule default to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Available targets:
 | ecs\_load\_balancers | A list of load balancer config objects for the ECS service; see `load_balancer` docs https://www.terraform.io/docs/providers/aws/r/ecs_service.html | <pre>list(object({<br>    container_name   = string<br>    container_port   = number<br>    elb_name         = string<br>    target_group_arn = string<br>  }))</pre> | `[]` | no |
 | enable\_all\_egress\_rule | A flag to enable/disable adding the all ports egress rule to the ECS security group | `bool` | `true` | no |
 | enable\_ecs\_managed\_tags | Specifies whether to enable Amazon ECS managed tags for the tasks within the service | `bool` | `false` | no |
-| enable\_icmp\_rule | Specifies whether to enable ICMP on the security group | `bool` | `true` | no |
+| enable\_icmp\_rule | Specifies whether to enable ICMP on the security group | `bool` | `false` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers | `number` | `0` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -58,7 +58,7 @@
 | ecs\_load\_balancers | A list of load balancer config objects for the ECS service; see `load_balancer` docs https://www.terraform.io/docs/providers/aws/r/ecs_service.html | <pre>list(object({<br>    container_name   = string<br>    container_port   = number<br>    elb_name         = string<br>    target_group_arn = string<br>  }))</pre> | `[]` | no |
 | enable\_all\_egress\_rule | A flag to enable/disable adding the all ports egress rule to the ECS security group | `bool` | `true` | no |
 | enable\_ecs\_managed\_tags | Specifies whether to enable Amazon ECS managed tags for the tasks within the service | `bool` | `false` | no |
-| enable\_icmp\_rule | Specifies whether to enable ICMP on the security group | `bool` | `true` | no |
+| enable\_icmp\_rule | Specifies whether to enable ICMP on the security group | `bool` | `false` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers | `number` | `0` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -261,7 +261,7 @@ variable "enable_ecs_managed_tags" {
 variable "enable_icmp_rule" {
   type        = bool
   description = "Specifies whether to enable ICMP on the security group"
-  default     = true
+  default     = false
 }
 
 variable "capacity_provider_strategies" {


### PR DESCRIPTION
## what
* Set enable_icmp_rule default to false

## why
* It doesn't make sense to me why icmp is enabled by default. It should be enabled if it's needed. I have to explicitly disable this one each service.

## references
* https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/issues/105

