### PR TITLE
Add create_before_destroy lifecycle to sg

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -238,7 +238,7 @@ resource "aws_iam_role_policy_attachment" "ecs_exec" {
 resource "aws_security_group" "ecs_service" {
   count       = local.enabled && var.network_mode == "awsvpc" ? 1 : 0
   vpc_id      = var.vpc_id
-  name        = module.service_label.id
+  name_prefix = module.service_label.id
   description = "Allow ALL egress from ECS service"
   tags        = module.service_label.tags
 

--- a/main.tf
+++ b/main.tf
@@ -238,7 +238,7 @@ resource "aws_iam_role_policy_attachment" "ecs_exec" {
 resource "aws_security_group" "ecs_service" {
   count       = local.enabled && var.network_mode == "awsvpc" ? 1 : 0
   vpc_id      = var.vpc_id
-  name_prefix = module.service_label.id
+  name        = module.service_label.id
   description = "Allow ALL egress from ECS service"
   tags        = module.service_label.tags
 

--- a/main.tf
+++ b/main.tf
@@ -241,6 +241,10 @@ resource "aws_security_group" "ecs_service" {
   name        = module.service_label.id
   description = "Allow ALL egress from ECS service"
   tags        = module.service_label.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "allow_all_egress" {


### PR DESCRIPTION
## what
* Add name_prefix and lifecycle to sg

## why
* Name changes to the security group may not be able to be destroyed easily. 

## references
* https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/issues/77

## note

Unsure if both the lifecycle and the `name_prefix` args need to be set. Might be good enough just to do the lifecycle.

I'm thinking it might be better to remove the `name_prefix` and see if the lifecycle clears the issue for the user.