### PR TITLE
enable_execute_command added to be able to use ECS Exec

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -336,3 +336,9 @@ variable "force_new_deployment" {
   description = "Enable to force a new task deployment of the service."
   default     = false
 }
+
+variable "exec_enabled" {
+  type        = bool
+  description = "Specifies whether to enable Amazon ECS Exec for the tasks within the service"
+  default     = false
+}

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.34"
     }
     template = {
       source  = "hashicorp/template"


### PR DESCRIPTION
## what
* `enable_execute_command` added

## why
*  to be able to use ECS Exec

## references
* https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
