### PR TITLE
remove unused provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,6 @@ Available targets:
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.34 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,7 +7,6 @@
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.34 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 

--- a/versions.tf
+++ b/versions.tf
@@ -5,10 +5,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.34"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
-    }
     local = {
       source  = "hashicorp/local"
       version = ">= 1.3"


### PR DESCRIPTION
## what
I removed the template provider
## why
It is not used anywhere and the provider itself is  deprecated and without a darwin arm64 release, making it unusable for new macbook users.

