### PR TITLE
Add desired_count to ignore_changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <!-- markdownlint-disable -->
 # terraform-aws-ecs-alb-service-task [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-ecs-alb-service-task.svg)](https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 <!-- markdownlint-restore -->
@@ -29,7 +30,6 @@
 
 Terraform module to create an ECS Service for a web app (task), and an ALB target group to route requests.
 
-
 ---
 
 This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
@@ -54,7 +54,6 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out!
-
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -392,7 +392,7 @@ resource "aws_ecs_service" "ignore_changes_task_definition" {
   }
 
   lifecycle {
-    ignore_changes = [task_definition]
+    ignore_changes = [task_definition, desired_count]
   }
 }
 
@@ -474,5 +474,9 @@ resource "aws_ecs_service" "default" {
       subnets          = var.subnet_ids
       assign_public_ip = var.assign_public_ip
     }
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
   }
 }


### PR DESCRIPTION
## what
* Ignoring desired count changes for aws_ecs_service

## why
* Desired count is a rough estimate that can be volatile during peak hours of the service that the containers serve
* Autoscaling policies may have scaled the number of tasks to above/below the desired count, so on a deployment of a new feature/change we don't want the desired count to be reset

## references
* No GitHub Issue for this as far as I'm aware

