### PR TITLE
Set enable_ecs_service_role to false when there is no load balancer

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   enabled                 = module.this.enabled
-  enable_ecs_service_role = module.this.enabled && var.network_mode != "awsvpc" && length(var.ecs_load_balancers) <= 1
+  enable_ecs_service_role = module.this.enabled && var.network_mode != "awsvpc" && length(var.ecs_load_balancers) == 1
   security_group_enabled  = module.this.enabled && var.security_group_enabled && var.network_mode == "awsvpc"
 }
 


### PR DESCRIPTION
## what
Set enable_ecs_service_role to false when there is no load balancer configured for the ECS service.

## why
When there is no load balancer defined for the ECS service(length(var.ecs_load_balancers==0), its service role is not needed. The argument 'iam_role' should be set to null.
In the current logic, the local variable 'enable_ecs_service_role' will be set to true even there is no load balancer defined. Correcting this by changing the condition to `length(var.ecs_load_balancers) == 1`

## references
With this bug, upgrading from <=0.25 from a config without load balancer will cause a replacement of resource aws_ecs_service.ignore_changes_task_definition, which will reset its 'task_definition' to the earliest version. There will be downtime.

