### PR TITLE
Fix "Reference to undeclared resource" when ignore_changes_desired_count is set to true

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -442,7 +442,7 @@ resource "aws_ecs_service" "ignore_changes_task_definition_and_desired_count" {
   dynamic "network_configuration" {
     for_each = var.network_mode == "awsvpc" ? ["true"] : []
     content {
-      security_groups  = compact(concat(var.security_group_ids, aws_security_group.ecs_service.*.id))
+      security_groups  = compact(concat(module.security_group.*.id, var.security_groups))
       subnets          = var.subnet_ids
       assign_public_ip = var.assign_public_ip
     }
@@ -527,7 +527,7 @@ resource "aws_ecs_service" "ignore_changes_desired_count" {
   dynamic "network_configuration" {
     for_each = var.network_mode == "awsvpc" ? ["true"] : []
     content {
-      security_groups  = compact(concat(var.security_group_ids, aws_security_group.ecs_service.*.id))
+      security_groups  = compact(concat(module.security_group.*.id, var.security_groups))
       subnets          = var.subnet_ids
       assign_public_ip = var.assign_public_ip
     }

--- a/terraform-aws-ecs-alb-service-task
+++ b/terraform-aws-ecs-alb-service-task
@@ -1,1 +1,0 @@
-terraform-aws-ecs-alb-service-task


### PR DESCRIPTION
## what
* #117 did not apply the change to how security groups are provisioned to `aws_ecs_service.ignore_changes_task_definition_and_desired_count` and `aws_ecs_service.ignore_changes_desired_count`
* This PR updates these two resources to use `module.security_group`, which the PR above introduced

## why
* Without this change, `terraform plan` fails with "Reference to undeclared resource" when `ignore_changes_desired_count` is set to `true` or both `ignore_changes_desired_count` and `ignore_changes_task_definition` are set to `true`

## references
* Follow-up to https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/commit/4988650f629e6968e1f76e88f15c6a699d7019b8#r52274665
