### PR TITLE
fix: ignore changes when deployment controller is codedeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Available targets:
 
 | Name | Type |
 |------|------|
+| [aws_ecs_service.codedeploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_service.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_service.ignore_changes_desired_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_service.ignore_changes_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -28,6 +28,7 @@
 
 | Name | Type |
 |------|------|
+| [aws_ecs_service.codedeploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_service.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_service.ignore_changes_desired_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_service.ignore_changes_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |

--- a/main.tf
+++ b/main.tf
@@ -274,7 +274,7 @@ module "security_group" {
 
 
 resource "aws_ecs_service" "ignore_changes_task_definition" {
-  count                              = local.enabled && var.ignore_changes_task_definition && ! var.ignore_changes_desired_count ? 1 : 0
+  count                              = local.enabled && var.ignore_changes_task_definition && !var.ignore_changes_desired_count && !local.controller_is_codedeploy ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count
@@ -364,7 +364,7 @@ resource "aws_ecs_service" "ignore_changes_task_definition" {
 }
 
 resource "aws_ecs_service" "ignore_changes_task_definition_and_desired_count" {
-  count                              = local.enabled && var.ignore_changes_task_definition && var.ignore_changes_desired_count ? 1 : 0
+  count                              = local.enabled && var.ignore_changes_task_definition && var.ignore_changes_desired_count && !local.controller_is_codedeploy ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count
@@ -453,8 +453,104 @@ resource "aws_ecs_service" "ignore_changes_task_definition_and_desired_count" {
   }
 }
 
+locals {
+  controller_is_codedeploy = var.deployment_controller_type == "CODE_DEPLOY"
+}
+
+# work around for this upstream issue: https://github.com/hashicorp/terraform-provider-aws/issues/13658
+# when deployment_controller is CODE_DEPLOY, network_configuration, task_definition, and desired_count must all be ignored.
+resource "aws_ecs_service" "codedeploy" {
+  count                              = local.enabled && local.controller_is_codedeploy ? 1 : 0
+  name                               = module.this.id
+  task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
+  desired_count                      = var.desired_count
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  health_check_grace_period_seconds  = var.health_check_grace_period_seconds
+  launch_type                        = length(var.capacity_provider_strategies) > 0 ? null : var.launch_type
+  platform_version                   = var.launch_type == "FARGATE" ? var.platform_version : null
+  scheduling_strategy                = var.launch_type == "FARGATE" ? "REPLICA" : var.scheduling_strategy
+  enable_ecs_managed_tags            = var.enable_ecs_managed_tags
+  iam_role                           = local.enable_ecs_service_role ? coalesce(var.service_role_arn, join("", aws_iam_role.ecs_service.*.arn)) : null
+  wait_for_steady_state              = var.wait_for_steady_state
+  force_new_deployment               = var.force_new_deployment
+  enable_execute_command             = var.exec_enabled
+
+  dynamic "capacity_provider_strategy" {
+    for_each = var.capacity_provider_strategies
+    content {
+      capacity_provider = capacity_provider_strategy.value.capacity_provider
+      weight            = capacity_provider_strategy.value.weight
+      base              = lookup(capacity_provider_strategy.value, "base", null)
+    }
+  }
+
+  dynamic "service_registries" {
+    for_each = var.service_registries
+    content {
+      registry_arn   = service_registries.value.registry_arn
+      port           = lookup(service_registries.value, "port", null)
+      container_name = lookup(service_registries.value, "container_name", null)
+      container_port = lookup(service_registries.value, "container_port", null)
+    }
+  }
+
+  dynamic "ordered_placement_strategy" {
+    for_each = var.ordered_placement_strategy
+    content {
+      type  = ordered_placement_strategy.value.type
+      field = lookup(ordered_placement_strategy.value, "field", null)
+    }
+  }
+
+  dynamic "placement_constraints" {
+    for_each = var.service_placement_constraints
+    content {
+      type       = placement_constraints.value.type
+      expression = lookup(placement_constraints.value, "expression", null)
+    }
+  }
+
+  dynamic "load_balancer" {
+    for_each = var.ecs_load_balancers
+    content {
+      container_name   = load_balancer.value.container_name
+      container_port   = load_balancer.value.container_port
+      elb_name         = lookup(load_balancer.value, "elb_name", null)
+      target_group_arn = lookup(load_balancer.value, "target_group_arn", null)
+    }
+  }
+
+  cluster        = var.ecs_cluster_arn
+  propagate_tags = var.propagate_tags
+  tags           = var.use_old_arn ? null : module.this.tags
+
+  deployment_controller {
+    type = var.deployment_controller_type
+  }
+
+  deployment_circuit_breaker {
+    enable   = var.circuit_breaker_deployment_enabled
+    rollback = var.circuit_breaker_rollback_enabled
+  }
+
+  # https://www.terraform.io/docs/providers/aws/r/ecs_service.html#network_configuration
+  dynamic "network_configuration" {
+    for_each = var.network_mode == "awsvpc" ? ["true"] : []
+    content {
+      security_groups  = compact(concat(var.security_group_ids, aws_security_group.ecs_service.*.id))
+      subnets          = var.subnet_ids
+      assign_public_ip = var.assign_public_ip
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [task_definition, desired_count, network_configuration]
+  }
+}
+
 resource "aws_ecs_service" "ignore_changes_desired_count" {
-  count                              = local.enabled && ! var.ignore_changes_task_definition && var.ignore_changes_desired_count ? 1 : 0
+  count                              = local.enabled && !var.ignore_changes_task_definition && var.ignore_changes_desired_count ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count
@@ -544,7 +640,7 @@ resource "aws_ecs_service" "ignore_changes_desired_count" {
 }
 
 resource "aws_ecs_service" "default" {
-  count                              = local.enabled && ! var.ignore_changes_task_definition && ! var.ignore_changes_desired_count ? 1 : 0
+  count                              = local.enabled && !var.ignore_changes_task_definition && !var.ignore_changes_desired_count && !local.controller_is_codedeploy ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count

--- a/main.tf
+++ b/main.tf
@@ -274,7 +274,7 @@ module "security_group" {
 
 
 resource "aws_ecs_service" "ignore_changes_task_definition" {
-  count                              = local.enabled && var.ignore_changes_task_definition && !var.ignore_changes_desired_count && !local.controller_is_codedeploy ? 1 : 0
+  count                              = local.enabled && var.ignore_changes_task_definition && ! var.ignore_changes_desired_count && ! local.controller_is_codedeploy ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count
@@ -364,7 +364,7 @@ resource "aws_ecs_service" "ignore_changes_task_definition" {
 }
 
 resource "aws_ecs_service" "ignore_changes_task_definition_and_desired_count" {
-  count                              = local.enabled && var.ignore_changes_task_definition && var.ignore_changes_desired_count && !local.controller_is_codedeploy ? 1 : 0
+  count                              = local.enabled && var.ignore_changes_task_definition && var.ignore_changes_desired_count && ! local.controller_is_codedeploy ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count
@@ -550,7 +550,7 @@ resource "aws_ecs_service" "codedeploy" {
 }
 
 resource "aws_ecs_service" "ignore_changes_desired_count" {
-  count                              = local.enabled && !var.ignore_changes_task_definition && var.ignore_changes_desired_count ? 1 : 0
+  count                              = local.enabled && ! var.ignore_changes_task_definition && var.ignore_changes_desired_count ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count
@@ -640,7 +640,7 @@ resource "aws_ecs_service" "ignore_changes_desired_count" {
 }
 
 resource "aws_ecs_service" "default" {
-  count                              = local.enabled && !var.ignore_changes_task_definition && !var.ignore_changes_desired_count && !local.controller_is_codedeploy ? 1 : 0
+  count                              = local.enabled && ! var.ignore_changes_task_definition && ! var.ignore_changes_desired_count && ! local.controller_is_codedeploy ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,7 +10,7 @@ output "ecs_exec_role_policy_name" {
 
 output "service_name" {
   description = "ECS Service name"
-  value       = try(aws_ecs_service.default[0].name, aws_ecs_service.ignore_changes_task_definition[0].name, aws_ecs_service.ignore_changes_desired_count[0].name, aws_ecs_service.ignore_changes_task_definition_and_desired_count[0].name, aws_ecs_service.codedeploy[0].id)
+  value       = try(aws_ecs_service.default[0].name, aws_ecs_service.ignore_changes_task_definition[0].name, aws_ecs_service.ignore_changes_desired_count[0].name, aws_ecs_service.ignore_changes_task_definition_and_desired_count[0].name, aws_ecs_service.codedeploy[0].name)
 }
 
 output "service_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,12 +10,12 @@ output "ecs_exec_role_policy_name" {
 
 output "service_name" {
   description = "ECS Service name"
-  value       = try(aws_ecs_service.default[0].name, aws_ecs_service.ignore_changes_task_definition[0].name, aws_ecs_service.ignore_changes_desired_count[0].name, aws_ecs_service.ignore_changes_task_definition_and_desired_count[0].name)
+  value       = try(aws_ecs_service.default[0].name, aws_ecs_service.ignore_changes_task_definition[0].name, aws_ecs_service.ignore_changes_desired_count[0].name, aws_ecs_service.ignore_changes_task_definition_and_desired_count[0].name, aws_ecs_service.codedeploy[0].id)
 }
 
 output "service_arn" {
   description = "ECS Service ARN"
-  value       = try(aws_ecs_service.default[0].id, aws_ecs_service.ignore_changes_task_definition[0].id, aws_ecs_service.ignore_changes_desired_count[0].id, aws_ecs_service.ignore_changes_task_definition_and_desired_count[0].id)
+  value       = try(aws_ecs_service.default[0].id, aws_ecs_service.ignore_changes_task_definition[0].id, aws_ecs_service.ignore_changes_desired_count[0].id, aws_ecs_service.ignore_changes_task_definition_and_desired_count[0].id, aws_ecs_service.codedeploy[0].id)
 }
 
 output "service_role_arn" {


### PR DESCRIPTION
## what
* adding yet another ecs_service block to work around this issue: https://github.com/hashicorp/terraform-provider-aws/issues/13658

## why
* when deployment_controller is CODE_DEPLOY, network_configuration, task_definition, and desired_count must all be ignored.

## references
* https://github.com/hashicorp/terraform-provider-aws/issues/13658
* Less weird than #119 and fixes the same issue 
