### PR TITLE
Change condition for ecs_load_balancers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   enabled                 = module.this.enabled
-  enable_ecs_service_role = module.this.enabled && var.network_mode != "awsvpc" && length(var.ecs_load_balancers) <= 1
+  enable_ecs_service_role = module.this.enabled && var.network_mode != "awsvpc" && length(var.ecs_load_balancers) >= 1
   security_group_enabled  = module.this.enabled && var.security_group_enabled && var.network_mode == "awsvpc"
 }
 


### PR DESCRIPTION
## what
* Changed condition for variable enable_ecs_service_role.

## why
* It is not possible to create a service without defining ecs_load_balancers variable and use "bridge" network_mode.

## references
* https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/issues/136