### PR TITLE
A managed resource "aws_security_group" "ecs_service" has not been declared in module.ecs_alb_service_task.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -442,7 +442,7 @@ resource "aws_ecs_service" "ignore_changes_task_definition_and_desired_count" {
   dynamic "network_configuration" {
     for_each = var.network_mode == "awsvpc" ? ["true"] : []
     content {
-      security_groups = compact(concat(module.security_group.*.id, var.security_groups))
+      security_groups  = compact(concat(module.security_group.*.id, var.security_groups))
       subnets          = var.subnet_ids
       assign_public_ip = var.assign_public_ip
     }
@@ -527,7 +527,7 @@ resource "aws_ecs_service" "ignore_changes_desired_count" {
   dynamic "network_configuration" {
     for_each = var.network_mode == "awsvpc" ? ["true"] : []
     content {
-      security_groups = compact(concat(module.security_group.*.id, var.security_groups))
+      security_groups  = compact(concat(module.security_group.*.id, var.security_groups))
       subnets          = var.subnet_ids
       assign_public_ip = var.assign_public_ip
     }

--- a/main.tf
+++ b/main.tf
@@ -442,7 +442,7 @@ resource "aws_ecs_service" "ignore_changes_task_definition_and_desired_count" {
   dynamic "network_configuration" {
     for_each = var.network_mode == "awsvpc" ? ["true"] : []
     content {
-      security_groups  = compact(concat(var.security_group_ids, aws_security_group.ecs_service.*.id))
+      security_groups = compact(concat(module.security_group.*.id, var.security_groups))
       subnets          = var.subnet_ids
       assign_public_ip = var.assign_public_ip
     }
@@ -527,7 +527,7 @@ resource "aws_ecs_service" "ignore_changes_desired_count" {
   dynamic "network_configuration" {
     for_each = var.network_mode == "awsvpc" ? ["true"] : []
     content {
-      security_groups  = compact(concat(var.security_group_ids, aws_security_group.ecs_service.*.id))
+      security_groups = compact(concat(module.security_group.*.id, var.security_groups))
       subnets          = var.subnet_ids
       assign_public_ip = var.assign_public_ip
     }


### PR DESCRIPTION
See issue https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/issues/139


## Why!!!?
Looks like there's a bug in the code if you use the `ignore` `desired_count` and `task_definition` flags! 😨 

Setting `var.ignore_changes_task_definition` or `var.ignore_changes_desired_count` or both(?) to `true` results in and error:

```
A managed resource "aws_security_group" "ecs_service" has not been declared in
module.ecs_alb_service_task.
```
I think that error makes sense as we don't have a `aws_security_group.ecs_service` resource in the module.

I took at look at the code [further down at](https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/blob/0922981957cfd72aa80c363c263cf54394a518f2/main.tf#L620) (the `default`)

and that (and this is what the tests use) references the `module` `security_group`: module.security_group.*.id

Which does exist 👍 

## references

I made an issue:

https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/issues/139

