### PR TITLE
Adds output for task exec role id

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ Available targets:
 | <a name="output_task_definition_family"></a> [task\_definition\_family](#output\_task\_definition\_family) | ECS task definition family |
 | <a name="output_task_definition_revision"></a> [task\_definition\_revision](#output\_task\_definition\_revision) | ECS task definition revision |
 | <a name="output_task_exec_role_arn"></a> [task\_exec\_role\_arn](#output\_task\_exec\_role\_arn) | ECS Task exec role ARN |
+| <a name="output_task_exec_role_id"></a> [task\_exec\_role\_id](#output\_task\_exec\_role\_id) | ECS Task exec role id |
 | <a name="output_task_exec_role_name"></a> [task\_exec\_role\_name](#output\_task\_exec\_role\_name) | ECS Task role name |
 | <a name="output_task_role_arn"></a> [task\_role\_arn](#output\_task\_role\_arn) | ECS Task role ARN |
 | <a name="output_task_role_id"></a> [task\_role\_id](#output\_task\_role\_id) | ECS Task role id |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -130,6 +130,7 @@
 | <a name="output_task_definition_family"></a> [task\_definition\_family](#output\_task\_definition\_family) | ECS task definition family |
 | <a name="output_task_definition_revision"></a> [task\_definition\_revision](#output\_task\_definition\_revision) | ECS task definition revision |
 | <a name="output_task_exec_role_arn"></a> [task\_exec\_role\_arn](#output\_task\_exec\_role\_arn) | ECS Task exec role ARN |
+| <a name="output_task_exec_role_id"></a> [task\_exec\_role\_id](#output\_task\_exec\_role\_id) | ECS Task exec role id |
 | <a name="output_task_exec_role_name"></a> [task\_exec\_role\_name](#output\_task\_exec\_role\_name) | ECS Task role name |
 | <a name="output_task_role_arn"></a> [task\_role\_arn](#output\_task\_role\_arn) | ECS Task role ARN |
 | <a name="output_task_role_id"></a> [task\_role\_id](#output\_task\_role\_id) | ECS Task role id |

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,6 +33,11 @@ output "task_exec_role_arn" {
   value       = length(var.task_exec_role_arn) > 0 ? var.task_exec_role_arn : join("", aws_iam_role.ecs_exec.*.arn)
 }
 
+output "task_exec_role_id" {
+  description = "ECS Task exec role id"
+  value       = join("", aws_iam_role.ecs_exec.*.unique_id)
+}
+
 output "task_role_name" {
   description = "ECS Task role name"
   value       = join("", aws_iam_role.ecs_task.*.name)


### PR DESCRIPTION
## what
* Adds output for the task exec role's unique id

## why
* Useful for permissions, it is already there for the task role

## references
* closes #142

