### PR TITLE
Fix Exception when no ALB is assigned to the service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   enabled                 = module.this.enabled
-  enable_ecs_service_role = module.this.enabled && var.network_mode != "awsvpc" && length(var.ecs_load_balancers) <= 1
+  enable_ecs_service_role = module.this.enabled && var.network_mode != "awsvpc" && length(var.ecs_load_balancers) == 1
   security_group_enabled  = module.this.enabled && var.security_group_enabled && var.network_mode == "awsvpc"
 }
 


### PR DESCRIPTION
If no ALB is assigned to the service, AWS throws the following exception:

```
InvalidParameterException: IAM roles are only valid for services configured to use load balancers.
```

