### PR TITLE
Don't create IAM role for the service if there are no load balancers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
   create_task_role        = local.enabled && length(var.task_role_arn) == 0
   task_exec_role_arn      = try(var.task_exec_role_arn[0], tostring(var.task_exec_role_arn), "")
   create_exec_role        = local.enabled && length(var.task_exec_role_arn) == 0
-  enable_ecs_service_role = module.this.enabled && var.network_mode != "awsvpc" && length(var.ecs_load_balancers) <= 1
+  enable_ecs_service_role = module.this.enabled && var.network_mode != "awsvpc" && length(var.ecs_load_balancers) >= 1
 
   volumes = concat(var.docker_volumes, var.efs_volumes)
 }


### PR DESCRIPTION
## what
* https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/pull/155 was meant/stated to fix https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/issues/136, but the PR didn't actually change the line that was causing the issue
* This PR makes the necessary change to fix the issue, which is to change the conditional for determining whether to create an IAM role for the ECS service that this module provisions: don't create the role if `var.ecs_load_balancers` is empty; otherwise, create it

## why
* The IAM role is assigned a policy that allows it to call load balancer APIs, which isn't necessary if no load balancing is needed
* Trying to attach the role to the ECS service anyways with network mode set to bridge results in an error as noted by #136

## references
Previous PRs
* https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/pull/118 (used `==` at first, later changed to `>=`)
* https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/pull/137 (uses `>=`, was closed in favor of #118)
* https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/pull/145 (uses `==`, was closed in favor of #155)

