### PR TITLE
Add empty string to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,12 +10,12 @@ output "ecs_exec_role_policy_name" {
 
 output "service_name" {
   description = "ECS Service name"
-  value       = try(aws_ecs_service.default[0].name, aws_ecs_service.ignore_changes_task_definition[0].name, aws_ecs_service.ignore_changes_desired_count[0].name, aws_ecs_service.ignore_changes_task_definition_and_desired_count[0].name)
+  value       = try(aws_ecs_service.default[0].name, aws_ecs_service.ignore_changes_task_definition[0].name, aws_ecs_service.ignore_changes_desired_count[0].name, aws_ecs_service.ignore_changes_task_definition_and_desired_count[0].name, "")
 }
 
 output "service_arn" {
   description = "ECS Service ARN"
-  value       = try(aws_ecs_service.default[0].id, aws_ecs_service.ignore_changes_task_definition[0].id, aws_ecs_service.ignore_changes_desired_count[0].id, aws_ecs_service.ignore_changes_task_definition_and_desired_count[0].id)
+  value       = try(aws_ecs_service.default[0].id, aws_ecs_service.ignore_changes_task_definition[0].id, aws_ecs_service.ignore_changes_desired_count[0].id, aws_ecs_service.ignore_changes_task_definition_and_desired_count[0].id, "")
 }
 
 output "service_role_arn" {


### PR DESCRIPTION
## what
*  Add empty string to the try function in service_name and service_arn outputs.

## why
*  Prevent error when module `enabled` is set to `false`.

![image](https://user-images.githubusercontent.com/19425457/149346468-6b487257-7f80-4635-8387-33ff6d8d29c0.png)
