### PR TITLE
Task Role uses for-each instead of count

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -280,9 +280,9 @@ data "aws_iam_policy_document" "ecs_exec" {
 
 resource "aws_iam_role_policy" "ecs_exec" {
   for_each = local.create_exec_role ? toset(["true"]) : toset([])
-  name   = module.exec_label.id
-  policy = join("", data.aws_iam_policy_document.ecs_exec.*.json)
-  role   = join("", aws_iam_role.ecs_exec.*.id)
+  name     = module.exec_label.id
+  policy   = join("", data.aws_iam_policy_document.ecs_exec.*.json)
+  role     = join("", aws_iam_role.ecs_exec.*.id)
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_exec" {
@@ -350,7 +350,7 @@ resource "aws_security_group_rule" "nlb" {
 }
 
 resource "aws_ecs_service" "ignore_changes_task_definition" {
-  count                              = local.ecs_service_enabled && var.ignore_changes_task_definition && !var.ignore_changes_desired_count ? 1 : 0
+  count                              = local.ecs_service_enabled && var.ignore_changes_task_definition && ! var.ignore_changes_desired_count ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count
@@ -536,7 +536,7 @@ resource "aws_ecs_service" "ignore_changes_task_definition_and_desired_count" {
 }
 
 resource "aws_ecs_service" "ignore_changes_desired_count" {
-  count                              = local.ecs_service_enabled && !var.ignore_changes_task_definition && var.ignore_changes_desired_count ? 1 : 0
+  count                              = local.ecs_service_enabled && ! var.ignore_changes_task_definition && var.ignore_changes_desired_count ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count
@@ -629,7 +629,7 @@ resource "aws_ecs_service" "ignore_changes_desired_count" {
 }
 
 resource "aws_ecs_service" "default" {
-  count                              = local.ecs_service_enabled && !var.ignore_changes_task_definition && !var.ignore_changes_desired_count ? 1 : 0
+  count                              = local.ecs_service_enabled && ! var.ignore_changes_task_definition && ! var.ignore_changes_desired_count ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count

--- a/main.tf
+++ b/main.tf
@@ -279,15 +279,15 @@ data "aws_iam_policy_document" "ecs_exec" {
 }
 
 resource "aws_iam_role_policy" "ecs_exec" {
-  count  = local.create_exec_role ? 1 : 0
+  for_each = local.create_exec_role ? toset(["true"]) : toset([])
   name   = module.exec_label.id
   policy = join("", data.aws_iam_policy_document.ecs_exec.*.json)
   role   = join("", aws_iam_role.ecs_exec.*.id)
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_exec" {
-  count      = local.create_exec_role ? length(var.task_exec_policy_arns) : 0
-  policy_arn = var.task_exec_policy_arns[count.index]
+  for_each   = local.create_exec_role ? toset(var.task_exec_policy_arns) : toset([])
+  policy_arn = each.value
   role       = join("", aws_iam_role.ecs_exec.*.id)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -279,8 +279,6 @@ data "aws_iam_policy_document" "ecs_exec" {
 }
 
 resource "aws_iam_role_policy" "ecs_exec" {
-#  count  = local.create_exec_role ? 1 : 0
-
   for_each = local.create_exec_role ? toset(["true"]) : toset([])
   name   = module.exec_label.id
   policy = join("", data.aws_iam_policy_document.ecs_exec.*.json)

--- a/main.tf
+++ b/main.tf
@@ -159,8 +159,8 @@ resource "aws_iam_role" "ecs_task" {
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task" {
-  count      = local.create_task_role ? length(var.task_policy_arns) : 0
-  policy_arn = var.task_policy_arns[count.index]
+  for_each   = local.create_task_role ? toset(var.task_policy_arns) : toset([])
+  policy_arn = each.value
   role       = join("", aws_iam_role.ecs_task.*.id)
 }
 
@@ -350,7 +350,7 @@ resource "aws_security_group_rule" "nlb" {
 }
 
 resource "aws_ecs_service" "ignore_changes_task_definition" {
-  count                              = local.ecs_service_enabled && var.ignore_changes_task_definition && ! var.ignore_changes_desired_count ? 1 : 0
+  count                              = local.ecs_service_enabled && var.ignore_changes_task_definition && !var.ignore_changes_desired_count ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count
@@ -536,7 +536,7 @@ resource "aws_ecs_service" "ignore_changes_task_definition_and_desired_count" {
 }
 
 resource "aws_ecs_service" "ignore_changes_desired_count" {
-  count                              = local.ecs_service_enabled && ! var.ignore_changes_task_definition && var.ignore_changes_desired_count ? 1 : 0
+  count                              = local.ecs_service_enabled && !var.ignore_changes_task_definition && var.ignore_changes_desired_count ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count
@@ -629,7 +629,7 @@ resource "aws_ecs_service" "ignore_changes_desired_count" {
 }
 
 resource "aws_ecs_service" "default" {
-  count                              = local.ecs_service_enabled && ! var.ignore_changes_task_definition && ! var.ignore_changes_desired_count ? 1 : 0
+  count                              = local.ecs_service_enabled && !var.ignore_changes_task_definition && !var.ignore_changes_desired_count ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count

--- a/main.tf
+++ b/main.tf
@@ -279,6 +279,8 @@ data "aws_iam_policy_document" "ecs_exec" {
 }
 
 resource "aws_iam_role_policy" "ecs_exec" {
+#  count  = local.create_exec_role ? 1 : 0
+
   for_each = local.create_exec_role ? toset(["true"]) : toset([])
   name   = module.exec_label.id
   policy = join("", data.aws_iam_policy_document.ecs_exec.*.json)

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,16 @@
 output "ecs_exec_role_policy_id" {
   description = "The ECS service role policy ID, in the form of `role_name:role_policy_name`"
-  value       = join("", aws_iam_role_policy.ecs_exec.*.id)
+  value = join("", [
+    for k, v in aws_iam_role_policy.ecs_exec : v.id
+  ])
+#  value       = join("", aws_iam_role_policy.ecs_exec[*].id)
 }
 
 output "ecs_exec_role_policy_name" {
   description = "ECS service role name"
-  value       = join("", aws_iam_role_policy.ecs_exec.*.name)
+  value = join("", [
+    for k, v in aws_iam_role_policy.ecs_exec : v.name
+  ])
 }
 
 output "service_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,6 @@ output "ecs_exec_role_policy_id" {
   value = join("", [
     for k, v in aws_iam_role_policy.ecs_exec : v.id
   ])
-#  value       = join("", aws_iam_role_policy.ecs_exec[*].id)
 }
 
 output "ecs_exec_role_policy_name" {


### PR DESCRIPTION
## what
* task role uses for each

## why
* fixes: #167 

## Note:
The outputs had to be changed to output a map as a single string, hence why they look complex, it's to keep backwards compatibility