### PR TITLE
Consistent types

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
   ecs_service_enabled     = local.enabled && var.ecs_service_enabled
   task_role_arn           = try(var.task_role_arn[0], tostring(var.task_role_arn), "")
   create_task_role        = local.enabled && length(var.task_role_arn) == 0
-  task_exec_role_arn      = try(var.task_exec_role_arn[0], tostring(var.task_exec_role_arn), "")
+  task_exec_role_arn      = try(tostring(var.task_exec_role_arn[0]), tostring(var.task_exec_role_arn), "")
   create_exec_role        = local.enabled && length(var.task_exec_role_arn) == 0
   enable_ecs_service_role = module.this.enabled && var.network_mode != "awsvpc" && length(var.ecs_load_balancers) >= 1
   create_security_group   = local.enabled && var.network_mode == "awsvpc" && var.security_group_enabled
@@ -350,7 +350,7 @@ resource "aws_security_group_rule" "nlb" {
 }
 
 resource "aws_ecs_service" "ignore_changes_task_definition" {
-  count                              = local.ecs_service_enabled && var.ignore_changes_task_definition && ! var.ignore_changes_desired_count ? 1 : 0
+  count                              = local.ecs_service_enabled && var.ignore_changes_task_definition && !var.ignore_changes_desired_count ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count
@@ -536,7 +536,7 @@ resource "aws_ecs_service" "ignore_changes_task_definition_and_desired_count" {
 }
 
 resource "aws_ecs_service" "ignore_changes_desired_count" {
-  count                              = local.ecs_service_enabled && ! var.ignore_changes_task_definition && var.ignore_changes_desired_count ? 1 : 0
+  count                              = local.ecs_service_enabled && !var.ignore_changes_task_definition && var.ignore_changes_desired_count ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count
@@ -629,7 +629,7 @@ resource "aws_ecs_service" "ignore_changes_desired_count" {
 }
 
 resource "aws_ecs_service" "default" {
-  count                              = local.ecs_service_enabled && ! var.ignore_changes_task_definition && ! var.ignore_changes_desired_count ? 1 : 0
+  count                              = local.ecs_service_enabled && !var.ignore_changes_task_definition && !var.ignore_changes_desired_count ? 1 : 0
   name                               = module.this.id
   task_definition                    = coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")
   desired_count                      = var.desired_count

--- a/variables.tf
+++ b/variables.tf
@@ -284,7 +284,10 @@ variable "efs_volumes" {
 }
 
 variable "bind_mount_volumes" {
-  type = list(any)
+  type = list(object({
+    host_path = string
+    name      = string
+  }))
   #  host_path = optional(string)
   #  name      = string
   description = "Task bind mount volume definitions as list of configuration objects. You can define multiple bind mount volumes on the same task definition. Requires `name` and optionally `host_path`"


### PR DESCRIPTION
## what

* changes `bind_mount_volumes` type to list(object())
* adds additional `tostring()` to `task_exec_role_arn` local logic
* runs `terraform fmt`

## why

* prevent `compact()` from causing terraform to crash (v 1.3.5 and 1.3.6)
* prevent terraform from complaining about inconsistent types for boolean operations

## references

* I have a complex config I'm working against that was generating these errors but if more context is needed please advise

