### PR TITLE
Remove excessive permissions from task exec role

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2023 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -266,7 +266,6 @@ data "aws_iam_policy_document" "ecs_exec" {
     resources = ["*"]
 
     actions = [
-      "ssm:GetParameters",
       "ecr:GetAuthorizationToken",
       "ecr:BatchCheckLayerAvailability",
       "ecr:GetDownloadUrlForLayer",


### PR DESCRIPTION
## what
* Remove `ssm:GetParameter`  action from task exec role

## why
* task execution role is too permissive for no good reason

## references
closes #189 

