### PR TITLE
updating to use var instead of id for ecs service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -362,7 +362,7 @@ resource "aws_security_group_rule" "nlb" {
 
 resource "aws_ecs_service" "ignore_changes_task_definition" {
   count                              = local.ecs_service_enabled && var.ignore_changes_task_definition && !var.ignore_changes_desired_count ? 1 : 0
-  name                               = module.this.id
+  name                               = var.ecs_service_name != null ? var.ecs_service_name : module.this.id
   task_definition                    = local.create_task_definition ? "${join("", aws_ecs_task_definition.default[*].family)}:${join("", aws_ecs_task_definition.default[*].revision)}" : var.task_definition[0]
   desired_count                      = var.desired_count
   deployment_maximum_percent         = var.deployment_maximum_percent
@@ -461,7 +461,7 @@ resource "aws_ecs_service" "ignore_changes_task_definition" {
 
 resource "aws_ecs_service" "ignore_changes_task_definition_and_desired_count" {
   count                              = local.ecs_service_enabled && var.ignore_changes_task_definition && var.ignore_changes_desired_count ? 1 : 0
-  name                               = module.this.id
+  name                               = var.ecs_service_name != null ? var.ecs_service_name : module.this.id
   task_definition                    = local.create_task_definition ? "${join("", aws_ecs_task_definition.default[*].family)}:${join("", aws_ecs_task_definition.default[*].revision)}" : var.task_definition[0]
   desired_count                      = var.desired_count
   deployment_maximum_percent         = var.deployment_maximum_percent
@@ -560,7 +560,7 @@ resource "aws_ecs_service" "ignore_changes_task_definition_and_desired_count" {
 
 resource "aws_ecs_service" "ignore_changes_desired_count" {
   count                              = local.ecs_service_enabled && !var.ignore_changes_task_definition && var.ignore_changes_desired_count ? 1 : 0
-  name                               = module.this.id
+  name                               = var.ecs_service_name != null ? var.ecs_service_name : module.this.id
   task_definition                    = local.create_task_definition ? "${join("", aws_ecs_task_definition.default[*].family)}:${join("", aws_ecs_task_definition.default[*].revision)}" : var.task_definition[0]
   desired_count                      = var.desired_count
   deployment_maximum_percent         = var.deployment_maximum_percent
@@ -659,7 +659,7 @@ resource "aws_ecs_service" "ignore_changes_desired_count" {
 
 resource "aws_ecs_service" "default" {
   count                              = local.ecs_service_enabled && !var.ignore_changes_task_definition && !var.ignore_changes_desired_count ? 1 : 0
-  name                               = module.this.id
+  name                               = var.ecs_service_name != null ? var.ecs_service_name : module.this.id
   task_definition                    = local.create_task_definition ? "${join("", aws_ecs_task_definition.default[*].family)}:${join("", aws_ecs_task_definition.default[*].revision)}" : var.task_definition[0]
   desired_count                      = var.desired_count
   deployment_maximum_percent         = var.deployment_maximum_percent

--- a/variables.tf
+++ b/variables.tf
@@ -503,6 +503,15 @@ variable "ecs_service_enabled" {
   default     = true
 }
 
+variable "ecs_service_name" {
+  type        = string
+  description = <<-EOT
+    If string is not null, use the string as the name of the ECS service.
+    Otherwise a name will be generated.
+    EOT
+  default     = null
+}
+
 variable "ipc_mode" {
   type        = string
   description = <<-EOT


### PR DESCRIPTION
## what

Updates the ECS service name to improve readability.

## why

So ECS service names don't get so clunky.

## references

Discovered when the following bug ticket was reported:
https://kininsurance.atlassian.net/browse/DK-369