### PR TITLE
fix typo and upgrade source versions

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -54,7 +54,7 @@ usage: |2-
   }
 
   module "label" {
-    source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.15.0"
+    source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.25.0"
     namespace  = var.namespace
     name       = var.name
     stage      = var.stage
@@ -64,7 +64,7 @@ usage: |2-
   }
 
   module "vpc" {
-    source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
+    source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/2.1.1"
     namespace  = var.namespace
     stage      = var.stage
     name       = var.name
@@ -75,7 +75,7 @@ usage: |2-
   }
 
   module "subnets" {
-    source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.1"
+    source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/2.4.2"
     availability_zones   = var.availability_zones
     namespace            = var.namespace
     stage                = var.stage
@@ -96,7 +96,7 @@ usage: |2-
   }
 
   module "container_definition" {
-    source                       = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=tags/0.21.0"
+    source                       = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=tags/0.61.0"
     container_name               = var.container_name
     container_image              = var.container_image
     container_memory             = var.container_memory
@@ -119,7 +119,7 @@ usage: |2-
     attributes                         = var.attributes
     delimiter                          = var.delimiter
     alb_security_group                 = module.vpc.vpc_default_security_group_id
-    container_definition_json          = module.container_definition.json
+    container_definition_json          = module.container_definition.json_map_encoded_list
     ecs_cluster_arn                    = aws_ecs_cluster.default.arn
     launch_type                        = var.ecs_launch_type
     vpc_id                             = module.vpc.vpc_id


### PR DESCRIPTION
## what

<!--
- This changes are upgrade of source versions, current source versions are not supporting latest terraform version (i.e >=1.10.5)
- There is a typo in README.yaml under module `ecs_alb_service_task` line `container_definition_json`, the value should be "module.container_definition.json_map_encoded_list" instead of "module.container_definition.json"
-->

## why

<!--
- To support latest terraform version and to fix typo for container_defination_json object in ecs_alb_service_task module. 
- This changes were made to support the current terraform version. the current source versions are very older. 
- Reference for typo link [here](https://github.com/JaydenMaalouf/terraform-aws-ecs-container-definition/tree/feat/restart-policies?tab=readme-ov-file#usage), can find under module "ecs_alb_service_task" of container_definition_json line.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
