### PR TITLE
ECS Service Autoscaling Support (Target Tracking Only)

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -80,3 +80,19 @@ container_port_mappings = [
 
 force_new_deployment = true
 redeploy_on_apply    = true
+
+service_autoscaling_enabled          = true
+service_autoscaling_minimum_capacity = 1
+service_autoscaling_maximum_capacity = 3
+service_autoscaling_target_tracking_policies = {
+  cpu = {
+    predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    target_value           = 50
+    scale_out_cooldown     = 60
+    scale_in_cooldown      = 60
+  },
+  memory = {
+    predefined_metric_type = "ECSServiceAverageMemoryUtilization"
+    target_value           = 80
+  }
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -17,7 +17,7 @@ module "vpc" {
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "2.1.0"
+  version = "2.4.2"
 
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
@@ -77,29 +77,33 @@ module "test_policy" {
 }
 
 module "ecs_alb_service_task" {
-  source                             = "../.."
-  alb_security_group                 = module.vpc.vpc_default_security_group_id
-  container_definition_json          = one(module.container_definition.*.json_map_encoded_list)
-  ecs_cluster_arn                    = one(aws_ecs_cluster.default.*.id)
-  launch_type                        = var.ecs_launch_type
-  vpc_id                             = module.vpc.vpc_id
-  security_group_ids                 = [module.vpc.vpc_default_security_group_id]
-  subnet_ids                         = module.subnets.public_subnet_ids
-  ignore_changes_task_definition     = var.ignore_changes_task_definition
-  network_mode                       = var.network_mode
-  assign_public_ip                   = var.assign_public_ip
-  propagate_tags                     = var.propagate_tags
-  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-  deployment_maximum_percent         = var.deployment_maximum_percent
-  deployment_controller_type         = var.deployment_controller_type
-  desired_count                      = var.desired_count
-  task_memory                        = var.task_memory
-  task_cpu                           = var.task_cpu
-  ecs_service_enabled                = var.ecs_service_enabled
-  force_new_deployment               = var.force_new_deployment
-  redeploy_on_apply                  = var.redeploy_on_apply
-  task_policy_arns                   = [module.test_policy.policy_arn]
-  task_exec_policy_arns_map          = { test = module.test_policy.policy_arn }
+  source                                       = "../.."
+  alb_security_group                           = module.vpc.vpc_default_security_group_id
+  container_definition_json                    = one(module.container_definition.*.json_map_encoded_list)
+  ecs_cluster_arn                              = one(aws_ecs_cluster.default.*.id)
+  launch_type                                  = var.ecs_launch_type
+  vpc_id                                       = module.vpc.vpc_id
+  security_group_ids                           = [module.vpc.vpc_default_security_group_id]
+  subnet_ids                                   = module.subnets.public_subnet_ids
+  ignore_changes_task_definition               = var.ignore_changes_task_definition
+  network_mode                                 = var.network_mode
+  assign_public_ip                             = var.assign_public_ip
+  propagate_tags                               = var.propagate_tags
+  deployment_minimum_healthy_percent           = var.deployment_minimum_healthy_percent
+  deployment_maximum_percent                   = var.deployment_maximum_percent
+  deployment_controller_type                   = var.deployment_controller_type
+  desired_count                                = var.desired_count
+  task_memory                                  = var.task_memory
+  task_cpu                                     = var.task_cpu
+  ecs_service_enabled                          = var.ecs_service_enabled
+  force_new_deployment                         = var.force_new_deployment
+  redeploy_on_apply                            = var.redeploy_on_apply
+  task_policy_arns                             = [module.test_policy.policy_arn]
+  task_exec_policy_arns_map                    = { test = module.test_policy.policy_arn }
+  service_autoscaling_enabled                  = var.service_autoscaling_enabled
+  service_autoscaling_minimum_capacity         = var.service_autoscaling_minimum_capacity
+  service_autoscaling_maximum_capacity         = var.service_autoscaling_maximum_capacity
+  service_autoscaling_target_tracking_policies = var.service_autoscaling_target_tracking_policies
 
   context = module.this.context
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -138,3 +138,39 @@ variable "redeploy_on_apply" {
   description = "Updates the service to the latest task definition on each apply"
   default     = false
 }
+
+variable "service_autoscaling_enabled" {
+  type        = bool
+  description = "Whether to enable autoscaling for the ECS service. This will cause the number of tasks to be adjusted based on the autoscaling policies defined."
+  default     = false
+}
+
+variable "service_autoscaling_minimum_capacity" {
+  type        = number
+  description = "The minimum number of tasks to keep running in the service. This is used for service autoscaling policies."
+  nullable    = true
+  default     = null
+}
+
+variable "service_autoscaling_maximum_capacity" {
+  type        = number
+  description = "The maximum number of tasks to keep running in the service. This is used for service autoscaling policies."
+  nullable    = true
+  default     = null
+}
+
+variable "service_autoscaling_target_tracking_policies" {
+  type = map(object({
+    predefined_metric_type = string
+    resource_label         = optional(string)
+    target_value           = number
+    scale_out_cooldown     = optional(number)
+    scale_in_cooldown      = optional(number)
+  }))
+  description = <<-EOT
+    A map of target tracking policies to use for ECS service autoscaling. Valid metrics types are `ECSServiceAverageCPUUtilization`, `ECSServiceAverageMemoryUtilization`, and `ALBRequestCountPerTarget`.
+    Note: `resource_label` is required for `ALBRequestCountPerTarget` metric type. This will be the last part of the target group ARN: `targetgroup/<target_group_name>/<target_group_id>`.
+    See the [documentation](https://docs.aws.amazon.com/autoscaling/application/APIReference/API_PredefinedMetricSpecification.html) for more details on predefined metrics.
+  EOT
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -258,6 +258,44 @@ variable "desired_count" {
   default     = 1
 }
 
+variable "service_autoscaling_enabled" {
+  type        = bool
+  description = "Whether to enable autoscaling for the ECS service. This will cause the number of tasks to be adjusted based on the autoscaling policies defined."
+  default     = false
+}
+
+variable "service_autoscaling_minimum_capacity" {
+  type        = number
+  description = "The minimum number of tasks to keep running in the service. This is used for service autoscaling policies."
+  nullable    = true
+  default     = null
+}
+
+variable "service_autoscaling_maximum_capacity" {
+  type        = number
+  description = "The maximum number of tasks to keep running in the service. This is used for service autoscaling policies."
+  nullable    = true
+  default     = null
+}
+
+variable "service_autoscaling_target_tracking_policies" {
+  type = map(object({
+    predefined_metric_type = string
+    resource_label         = optional(string)
+    target_value           = number
+    scale_out_cooldown     = optional(number)
+    scale_in_cooldown      = optional(number)
+  }))
+  description = <<-EOT
+    A map of target tracking policies to use for ECS service autoscaling.
+    Valid metrics types are `ECSServiceAverageCPUUtilization`, `ECSServiceAverageMemoryUtilization`, and `ALBRequestCountPerTarget`.
+    If `ALBRequestCountPerTarget` is used, the `resource_label` must be specified as the final part of the target group ARN. (`targetgroup/<target-group-name>/<target-group-id>`)
+    See the docs for more details: [Predefined Metric Specification](https://docs.aws.amazon.com/autoscaling/plans/APIReference/API_PredefinedScalingMetricSpecification.html)
+  EOT
+  default     = {}
+}
+
+
 variable "deployment_controller_type" {
   type        = string
   description = "Type of deployment controller. Valid values are `CODE_DEPLOY` and `ECS`"

--- a/variables.tf
+++ b/variables.tf
@@ -287,10 +287,9 @@ variable "service_autoscaling_target_tracking_policies" {
     scale_in_cooldown      = optional(number)
   }))
   description = <<-EOT
-    A map of target tracking policies to use for ECS service autoscaling.
-    Valid metrics types are `ECSServiceAverageCPUUtilization`, `ECSServiceAverageMemoryUtilization`, and `ALBRequestCountPerTarget`.
-    If `ALBRequestCountPerTarget` is used, the `resource_label` must be specified as the final part of the target group ARN. (`targetgroup/<target-group-name>/<target-group-id>`)
-    See the docs for more details: [Predefined Metric Specification](https://docs.aws.amazon.com/autoscaling/plans/APIReference/API_PredefinedScalingMetricSpecification.html)
+  A map of target tracking policies to use for ECS service autoscaling. Valid metrics types are `ECSServiceAverageCPUUtilization`, `ECSServiceAverageMemoryUtilization`, and `ALBRequestCountPerTarget`.
+  Note: `resource_label` is required for `ALBRequestCountPerTarget` metric type. This will be the last part of the target group ARN: `targetgroup/<target_group_name>/<target_group_id>`.
+  See the [documentation](https://docs.aws.amazon.com/autoscaling/application/APIReference/API_PredefinedMetricSpecification.html) for more details on predefined metrics.
   EOT
   default     = {}
 }


### PR DESCRIPTION
## what
- Added support ECS service autoscaling via the target tracking policies.
- Update examples/complete with a simple implementation of average CPU and memory utilization autoscaling.

## why
- Service autoscaling is crucial for production applications with unpredictable work volumes.
- Best practices regarding cost optimisation and performance efficiency pillars.

## references
- https://docs.aws.amazon.com/autoscaling/application/APIReference
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_policy
