### PR TITLE
fix: test examples/complete subnet

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -17,7 +17,7 @@ module "vpc" {
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "2.1.0"
+  version = "2.4.2"
 
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id


### PR DESCRIPTION
Tests are failing
```
Error: Unsupported argument
on .terraform/modules/subnets/main.tf line 286, in resource "aws_eip" "default":
286:   vpc = true

An argument named "vpc" is not expected here.
```

Fix by upgrading to the latest module for the `examples/complete`